### PR TITLE
add: option to share selenium web driver in test or not

### DIFF
--- a/test/test_web.py
+++ b/test/test_web.py
@@ -67,7 +67,6 @@ class AbstractWebTest(unittest.TestCase):
         self.server_runner = InterfaceThreadRunner(shc.web.WebServer, "localhost", 42080, 'index')
         self.server = self.server_runner.interface
 
-
     @classmethod
     def setUpClass(cls) -> None:
         if cls.share_selenium_web_driver():
@@ -102,6 +101,7 @@ class AbstractWebTest(unittest.TestCase):
             return False
 
         return True
+
 
 class SimpleWebTest(AbstractWebTest):
     def test_basic(self) -> None:

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -91,7 +91,7 @@ class AbstractWebTest(unittest.TestCase):
         """Should the selenium driver be shared or not.
 
         Checks whether the environment variable SHARE_SELENIUM_WEB_DRIVER is set.
-        On WSL default ist not sharing the driver since this causes concirrency conflicts.
+        On WSL default ist not sharing the driver since this causes concurrency conflicts.
         """
         if (value := os.getenv('SHARE_SELENIUM_WEB_DRIVER')) is not None:
             return value.strip().lower() in ['1', 'true', 'yes', 'on']

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -53,8 +53,7 @@ class StatusTestInterface(ReadableStatusInterface):
         return f"StatusTestInterface({self.name})"
 
 
-@unittest.skipIf(shutil.which("geckodriver") is None,
-                 "Selenium's geckodriver is not available in PATH")
+@unittest.skipIf(shutil.which("geckodriver") is None, "Selenium's geckodriver is not available in PATH")
 class AbstractWebTest(unittest.TestCase):
     driver: webdriver.Firefox
 


### PR DESCRIPTION
Sharing the selenium driver in the web tests is now optional.  Since sharing the web driver causes concurrency issues on e.g. WSL it can now be configured by setting the environment variable `SHARE_SELENIUM_WEB_DRIVER`.  

Running on WSL defaults to not share the driver but can be overwritten w/ above environment variable.

All other OS will share the driver by default unless `SHARE_SELENIUM_WEB_DRIVER` is set to True.