### PR TITLE
Ruff format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,7 +130,7 @@ ignore_missing_imports = true
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.
-# quote-style = "double"
+quote-style = "double"
 
 # Like Black, indent with spaces, rather than tabs.
 indent-style = "space"

--- a/shc/conversion.py
+++ b/shc/conversion.py
@@ -14,8 +14,8 @@ import enum
 import json
 from typing import TypeVar, Dict, Tuple, Type, Callable, Any
 
-S = TypeVar('S')
-T = TypeVar('T')
+S = TypeVar("S")
+T = TypeVar("T")
 
 _TYPE_CONVERSIONS: Dict[Tuple[Type, Type], Callable[[Any], Any]] = {}
 _JSON_CONVERSIONS: Dict[Type, Tuple[Callable[[Any], Any], Callable[[Any], Any]]] = {}
@@ -41,8 +41,9 @@ def get_converter(from_type: Type[S], to_type: Type[T]) -> Callable[[S], T]:
     try:
         return _TYPE_CONVERSIONS[(from_type, to_type)]
     except KeyError as e:
-        raise TypeError("No converter available to convert {} into {}"
-                        .format(from_type.__name__, to_type.__name__)) from e
+        raise TypeError(
+            "No converter available to convert {} into {}".format(from_type.__name__, to_type.__name__)
+        ) from e
 
 
 class SHCJsonEncoder(json.JSONEncoder):
@@ -76,8 +77,8 @@ register_converter(str, float, lambda v: float(v))
 register_converter(int, bool, lambda v: bool(v))
 register_converter(float, bool, lambda v: bool(v))
 register_converter(str, bool, lambda v: bool(v))
-register_converter(bytes, str, lambda v: v.decode('utf-8-sig'))
-register_converter(str, bytes, lambda v: v.encode('utf-8'))
+register_converter(bytes, str, lambda v: v.decode("utf-8-sig"))
+register_converter(str, bytes, lambda v: v.encode("utf-8"))
 register_json_conversion(datetime.date, lambda o: o.isoformat(), lambda v: datetime.date.fromisoformat(v))
 register_json_conversion(datetime.datetime, lambda o: o.isoformat(), lambda v: datetime.datetime.fromisoformat(v))
 register_json_conversion(datetime.timedelta, lambda o: o.total_seconds(), lambda v: datetime.timedelta(seconds=v))

--- a/shc/datatypes.py
+++ b/shc/datatypes.py
@@ -23,6 +23,7 @@ class RangeFloat1(float):
     """
     A range / percentage value, represented as a floating point number from 0.0 (0%) to 1.0 (100%).
     """
+
     def __new__(cls, *args, **kwargs):
         # noinspection PyArgumentList
         res = float.__new__(cls, *args, **kwargs)
@@ -54,6 +55,7 @@ class RangeUInt8(int):
     """
     A range / percentage value, represented as an 8bit integer number from 0 (0%) to 255 (100%).
     """
+
     @classmethod
     def from_float(cls, value: float) -> "RangeUInt8":
         if not isinstance(value, RangeFloat1):
@@ -68,6 +70,7 @@ class RangeInt0To100(int):
     """
     A range / percentage value, represented as an 8bit integer percent number from 0 (0%) to 100 (100%).
     """
+
     @classmethod
     def from_float(cls, value: float) -> "RangeInt0To100":
         if not isinstance(value, RangeFloat1):
@@ -104,6 +107,7 @@ class AngleUInt8(int):
     """
     An angle, encoded as a 8-bit integer, from 0 (0°) to 255 (360°).
     """
+
     pass
 
 
@@ -117,6 +121,7 @@ class Balance(float):
     - front (surround audio balance)
     - no LFE (surround audio balance)
     """
+
     pass
 
 
@@ -128,6 +133,7 @@ class AbstractStep(Generic[T], metaclass=abc.ABCMeta):
     """
     Abstract base class for all difference/step types, that represent a step within an associated range type
     """
+
     @abc.abstractmethod
     def apply_to(self, value: T) -> T:
         """
@@ -146,6 +152,7 @@ class FadeStep(float, AbstractStep[RangeFloat1]):
 
     See :class:`shc.misc.FadeStepAdapter` to do this to SHC.
     """
+
     pass
 
     def apply_to(self, value: RangeFloat1) -> RangeFloat1:
@@ -159,6 +166,7 @@ class RGBUInt8(NamedTuple):
     """
     A 24bit color in RGB colorspace, composed of three :class:`RangeUInt8` values `red`, `green` and `blue`
     """
+
     red: RangeUInt8
     green: RangeUInt8
     blue: RangeUInt8
@@ -167,26 +175,27 @@ class RGBUInt8(NamedTuple):
         if not isinstance(other, RangeFloat1):
             other = get_converter(type(other), RangeFloat1)(other)
 
-        return RGBUInt8(RangeUInt8.from_float(self.red.as_float() * other),
-                        RangeUInt8.from_float(self.green.as_float() * other),
-                        RangeUInt8.from_float(self.blue.as_float() * other))
+        return RGBUInt8(
+            RangeUInt8.from_float(self.red.as_float() * other),
+            RangeUInt8.from_float(self.green.as_float() * other),
+            RangeUInt8.from_float(self.blue.as_float() * other),
+        )
 
     @classmethod
     def from_float(cls, value: "RGBFloat1") -> "RGBUInt8":
-        return RGBUInt8(RangeUInt8.from_float(value.red),
-                        RangeUInt8.from_float(value.green),
-                        RangeUInt8.from_float(value.blue))
+        return RGBUInt8(
+            RangeUInt8.from_float(value.red), RangeUInt8.from_float(value.green), RangeUInt8.from_float(value.blue)
+        )
 
     def as_float(self) -> "RGBFloat1":
-        return RGBFloat1(self.red.as_float(),
-                         self.green.as_float(),
-                         self.blue.as_float())
+        return RGBFloat1(self.red.as_float(), self.green.as_float(), self.blue.as_float())
 
 
 class RGBFloat1(NamedTuple):
     """
     A floating point RGB color, composed of three :class:`RangeFloat1` values `red`, `green` and `blue`
     """
+
     red: RangeFloat1
     green: RangeFloat1
     blue: RangeFloat1
@@ -195,9 +204,7 @@ class RGBFloat1(NamedTuple):
         if not isinstance(other, RangeFloat1):
             other = get_converter(type(other), RangeFloat1)(other)
 
-        return RGBFloat1(self.red * other,
-                         self.green * other,
-                         self.blue * other)
+        return RGBFloat1(self.red * other, self.green * other, self.blue * other)
 
 
 register_converter(RGBUInt8, RGBFloat1, lambda v: v.as_float())
@@ -209,6 +216,7 @@ class HSVFloat1(NamedTuple):
     A floating point color in HSV colorspace, composed of three :class:`RangeFloat1` values `hue`, `saturation` and
     `value`.
     """
+
     hue: RangeFloat1
     saturation: RangeFloat1
     value: RangeFloat1
@@ -226,10 +234,15 @@ class HSVFloat1(NamedTuple):
         b = value.blue
         max_v = max(r, g, b)
         min_v = min(r, g, b)
-        h = (0 if max_v == min_v
-             else 1/6 * (g - b) / (max_v - min_v) if max_v == r
-             else 2/6 + 1/6 * (b - r) / (max_v - min_v) if max_v == g
-             else 4/6 + 1/6 * (r - g) / (max_v - min_v))
+        h = (
+            0
+            if max_v == min_v
+            else 1 / 6 * (g - b) / (max_v - min_v)
+            if max_v == r
+            else 2 / 6 + 1 / 6 * (b - r) / (max_v - min_v)
+            if max_v == g
+            else 4 / 6 + 1 / 6 * (r - g) / (max_v - min_v)
+        )
         s = 0 if max_v == 0 else (max_v - min_v) / max_v
         v = max_v
         if h < 0:
@@ -247,12 +260,19 @@ class HSVFloat1(NamedTuple):
         q = v * (1 - s * f)
         t = v * (1 - s * (1 - f))
 
-        r, g, b = ((v, t, p) if hi in (0, 6)
-                   else (q, v, p) if hi == 1
-                   else (p, v, t) if hi == 2
-                   else (p, q, v) if hi == 3
-                   else (t, p, v) if hi == 4
-                   else (v, p, q))  # if hi == 5
+        r, g, b = (
+            (v, t, p)
+            if hi in (0, 6)
+            else (q, v, p)
+            if hi == 1
+            else (p, v, t)
+            if hi == 2
+            else (p, q, v)
+            if hi == 3
+            else (t, p, v)
+            if hi == 4
+            else (v, p, q)
+        )  # if hi == 5
         return RGBFloat1(RangeFloat1(r), RangeFloat1(g), RangeFloat1(b))
 
 
@@ -266,6 +286,7 @@ class RGBWUInt8(NamedTuple):
     """
     4-channel RGBW LED color value, composed of a :class:`RGBUInt8` for `rgb` and a :class:`RangeUInt8` for `white`.
     """
+
     rgb: RGBUInt8
     white: RangeUInt8
 
@@ -273,8 +294,7 @@ class RGBWUInt8(NamedTuple):
         if not isinstance(other, RangeFloat1):
             other = get_converter(type(other), RangeFloat1)(other)
 
-        return RGBWUInt8(self.rgb.dimmed(other),
-                         RangeUInt8.from_float(self.white.as_float() * other))
+        return RGBWUInt8(self.rgb.dimmed(other), RangeUInt8.from_float(self.white.as_float() * other))
 
 
 register_converter(RGBWUInt8, RGBUInt8, lambda x: x.rgb)
@@ -285,6 +305,7 @@ class CCTUInt8(NamedTuple):
     """
     A CCT LED brightness value, composed of two :class:`RangeUInt8` values `cold` and `warm`
     """
+
     cold: RangeUInt8
     warm: RangeUInt8
 
@@ -292,14 +313,16 @@ class CCTUInt8(NamedTuple):
         if not isinstance(other, RangeFloat1):
             other = get_converter(type(other), RangeFloat1)(other)
 
-        return CCTUInt8(RangeUInt8.from_float(self.cold.as_float() * other),
-                        RangeUInt8.from_float(self.warm.as_float() * other))
+        return CCTUInt8(
+            RangeUInt8.from_float(self.cold.as_float() * other), RangeUInt8.from_float(self.warm.as_float() * other)
+        )
 
 
 class RGBCCTUInt8(NamedTuple):
     """
     5 channel LED color value, composed of a :class:`RGBUInt8` for `rgb` and a :class:`CCTUInt8` for `white`.
     """
+
     rgb: RGBUInt8
     white: CCTUInt8
 
@@ -310,12 +333,13 @@ class RGBCCTUInt8(NamedTuple):
         return RGBCCTUInt8(self.rgb.dimmed(other), self.white.dimmed(other))
 
 
-register_converter(CCTUInt8, RangeUInt8, lambda x: RangeUInt8((x.cold + x.warm)/2))
+register_converter(CCTUInt8, RangeUInt8, lambda x: RangeUInt8((x.cold + x.warm) / 2))
 register_converter(RangeUInt8, CCTUInt8, lambda x: CCTUInt8(x, x))
 register_converter(RGBCCTUInt8, RGBUInt8, lambda x: x.rgb)
 register_converter(RGBUInt8, RGBCCTUInt8, lambda x: RGBCCTUInt8(x, CCTUInt8(RangeUInt8(0), RangeUInt8(0))))
 register_converter(RGBCCTUInt8, CCTUInt8, lambda x: x.white)
-register_converter(CCTUInt8, RGBCCTUInt8, lambda x: RGBCCTUInt8(RGBUInt8(RangeUInt8(0), RangeUInt8(0), RangeUInt8(0)),
-                                                                x))
-register_converter(RGBCCTUInt8, RGBWUInt8, lambda x: RGBWUInt8(x.rgb, RangeUInt8((x.white.cold + x.white.warm)/2)))
+register_converter(
+    CCTUInt8, RGBCCTUInt8, lambda x: RGBCCTUInt8(RGBUInt8(RangeUInt8(0), RangeUInt8(0), RangeUInt8(0)), x)
+)
+register_converter(RGBCCTUInt8, RGBWUInt8, lambda x: RGBWUInt8(x.rgb, RangeUInt8((x.white.cold + x.white.warm) / 2)))
 register_converter(RGBWUInt8, RGBCCTUInt8, lambda x: RGBCCTUInt8(x.rgb, CCTUInt8(x.white, x.white)))

--- a/shc/interfaces/_helper.py
+++ b/shc/interfaces/_helper.py
@@ -28,6 +28,7 @@ class ReadableStatusInterface(AbstractInterface, metaclass=abc.ABCMeta):
     *readable* connector that triggers this interfaces health checks when being *read*. The health checks must be
     implemented for each interface implementation by overriding the :meth:`_get_status` method.
     """
+
     def __init__(self):
         super().__init__()
         self.__status_connector: Optional[ReadableStatusConnector] = None
@@ -130,6 +131,7 @@ class SupervisedClientInterface(SubscribableStatusInterface, metaclass=abc.ABCMe
     `metrics`. So, you can fill the `metrics` with custom values from your derived interface class via
     ``self._status_connector.update_status(metrics={…})``.
     """
+
     def __init__(self, auto_reconnect: bool = True, failsafe_start: bool = False):
         """
         :param auto_reconnect: If True (default), the supervisor tries to reconnect the interface automatically with
@@ -345,8 +347,9 @@ class SupervisedClientInterface(SubscribableStatusInterface, metaclass=abc.ABCMe
                 await run_task
             run_exception = run_task.exception()
             if run_exception:
-                raise RuntimeError("Run task raised an exception while awaiting _subscribe: %s", repr(run_exception)) \
-                    from run_exception
+                raise RuntimeError(
+                    "Run task raised an exception while awaiting _subscribe: %s", repr(run_exception)
+                ) from run_exception
             else:
                 raise RuntimeError("Run task stopped before _subscribe task finished")
         subscribe_exception = subscribe_task.exception()
@@ -355,8 +358,12 @@ class SupervisedClientInterface(SubscribableStatusInterface, metaclass=abc.ABCMe
             try:
                 await run_task
             except Exception as e:
-                logger.debug("Ignoring Exception %s in run task of interface %s, during shutdown due to "
-                             "exception in _subscribe task", repr(e), self)
+                logger.debug(
+                    "Ignoring Exception %s in run task of interface %s, during shutdown due to "
+                    "exception in _subscribe task",
+                    repr(e),
+                    self,
+                )
             raise subscribe_exception
 
     async def __handle_exception(self, exception: Optional[Exception]) -> bool:
@@ -411,6 +418,7 @@ class SupervisedClientInterface(SubscribableStatusInterface, metaclass=abc.ABCMe
             self._status_connector.update_status(status=ServiceStatus.CRITICAL, message=str(exception))
         else:
             logger.error("Unexpected shutdown of interface %s. Attempting reconnect ...", self)
-            self._status_connector.update_status(status=ServiceStatus.CRITICAL,
-                                                 message="Unexpected shutdown of interface")
+            self._status_connector.update_status(
+                status=ServiceStatus.CRITICAL, message="Unexpected shutdown of interface"
+            )
         return False

--- a/shc/interfaces/_pulse_ffi.py
+++ b/shc/interfaces/_pulse_ffi.py
@@ -8,16 +8,17 @@
 # Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
 # specific language governing permissions and limitations under the License.
-""" Outsourced C function bindings for volume conversion in the pulse interface datatypes.
+"""Outsourced C function bindings for volume conversion in the pulse interface datatypes.
 
 Loading this module requires libpulse to be installed.
 """
+
 import ctypes as c
 import ctypes.util
 from pulsectl._pulsectl import PA_CVOLUME, PA_CHANNEL_MAP
 
 
-libpulse = c.CDLL(ctypes.util.find_library('libpulse') or 'libpulse.so.0')
+libpulse = c.CDLL(ctypes.util.find_library("libpulse") or "libpulse.so.0")
 
 pa_volume_t = c.c_uint32
 pa_cvolume_max = libpulse.pa_cvolume_max

--- a/shc/interfaces/command.py
+++ b/shc/interfaces/command.py
@@ -1,4 +1,5 @@
 """Command interface."""
+
 import asyncio
 import logging
 from typing import List, Union, cast
@@ -28,6 +29,7 @@ class Command(Readable[str]):
     :param check: If True, the exit code of the command will be checked the read() method raises an UninitializedError
         instead of returning the output of the command in case of a non-zero exit code.
     """
+
     type = str
 
     def __init__(self, command: Union[str, List[str]], shell=False, include_std_err=False, check=False):
@@ -43,14 +45,14 @@ class Command(Readable[str]):
         stderr = asyncio.subprocess.STDOUT if self.include_std_err else asyncio.subprocess.DEVNULL
         if self.shell:
             command = cast(str, self.command)
-            command_process = await asyncio.create_subprocess_shell(command,
-                                                                    stdout=asyncio.subprocess.PIPE,
-                                                                    stderr=stderr)
+            command_process = await asyncio.create_subprocess_shell(
+                command, stdout=asyncio.subprocess.PIPE, stderr=stderr
+            )
         else:
             command_args = cast(List[str], self.command)
-            command_process = await asyncio.create_subprocess_exec(*command_args,
-                                                                   stdout=asyncio.subprocess.PIPE,
-                                                                   stderr=stderr)
+            command_process = await asyncio.create_subprocess_exec(
+                *command_args, stdout=asyncio.subprocess.PIPE, stderr=stderr
+            )
 
         std_out, _std_err = await command_process.communicate()
         if self.check:
@@ -79,6 +81,7 @@ class CommandExitCode(Readable[int]):
         it should be list of the command and its individual command line arguments.
     :param shell: If True, the command will be within a shell, otherwise it will be started as a plain subprocess
     """
+
     type = int
 
     def __init__(self, command: Union[str, List[str]], shell=False):
@@ -90,14 +93,14 @@ class CommandExitCode(Readable[int]):
     async def read(self) -> int:
         if self.shell:
             command = cast(str, self.command)
-            command_process = await asyncio.create_subprocess_shell(command,
-                                                                    stdout=asyncio.subprocess.DEVNULL,
-                                                                    stderr=asyncio.subprocess.DEVNULL)
+            command_process = await asyncio.create_subprocess_shell(
+                command, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+            )
         else:
             command_args = cast(List[str], self.command)
-            command_process = await asyncio.create_subprocess_exec(*command_args,
-                                                                   stdout=asyncio.subprocess.DEVNULL,
-                                                                   stderr=asyncio.subprocess.DEVNULL)
+            command_process = await asyncio.create_subprocess_exec(
+                *command_args, stdout=asyncio.subprocess.DEVNULL, stderr=asyncio.subprocess.DEVNULL
+            )
 
         result = await command_process.wait()
         return result

--- a/shc/interfaces/dmx.py
+++ b/shc/interfaces/dmx.py
@@ -57,6 +57,7 @@ class AbstractDMXConnector(AbstractInterface, metaclass=abc.ABCMeta):
 
     Instances of these classes provide a method :meth:`address` to create a `writable` object for a given DMX channel.
     """
+
     def __init__(self, universe_size: int = 512):
         super().__init__()
         self.universe = [0] * universe_size
@@ -92,6 +93,7 @@ class DMXAddress(Writable[RangeUInt8]):
     Writing a value to a `DMXAddress` object sets the corresponding channel in the cached DMX universe to that value and
     triggers transmission of the universe to the hardware DMX interface.
     """
+
     type = RangeUInt8
 
     def __init__(self, connector: AbstractDMXConnector, address: int) -> None:
@@ -108,6 +110,7 @@ class EnttecDMXUSBProConnector(AbstractDMXConnector):
     """
     A DMX Interface for the Enttec DMX USB PRO and compatible devices (with the same serial protocol).
     """
+
     # Build according to this spec:
     # https://web.archive.org/web/20200822142042/https://dol2kh495zr52.cloudfront.net/pdf/misc/dmx_usb_pro_api_spec.pdf
 
@@ -129,8 +132,8 @@ class EnttecDMXUSBProConnector(AbstractDMXConnector):
 
     @staticmethod
     def _universe_to_enttec(universe: List[int]) -> "EnttecMessage":
-        """ Helper method to serialize a DMX universe (as List[int]) into an EnttacMessage to be sent to the DMX
-        interface """
+        """Helper method to serialize a DMX universe (as List[int]) into an EnttacMessage to be sent to the DMX
+        interface"""
         DMX_LIGHTNING_DATA_START_CODE = 0
         data = bytes([DMX_LIGHTNING_DATA_START_CODE] + universe + [0] * (24 - len(universe)))
         return EnttecMessage(EntTecMessageLabel.OUTPUT_ONLY_SEND_DMX_PACKET, data)
@@ -163,8 +166,10 @@ class EnttecDMXUSBProConnector(AbstractDMXConnector):
 
         # In case there is a running _transmit and a Future for the next, simply await that future.
         else:
-            logger.debug("DMX transmit is already running. Queued next transmit already exists. Wating for queued "
-                         "transmit to finish ...")
+            logger.debug(
+                "DMX transmit is already running. Queued next transmit already exists. Wating for queued "
+                "transmit to finish ..."
+            )
             await self.next_transmit
 
     async def _transmit(self) -> None:
@@ -201,4 +206,4 @@ class EnttecMessage(NamedTuple):
 
     def encode(self) -> bytes:
         length = len(self.data)
-        return bytes((0x7e, self.label.value, length & 0xff, (length >> 8) & 0xff)) + self.data + bytes((0xe7,))
+        return bytes((0x7E, self.label.value, length & 0xFF, (length >> 8) & 0xFF)) + self.data + bytes((0xE7,))

--- a/shc/interfaces/in_memory_data_logging.py
+++ b/shc/interfaces/in_memory_data_logging.py
@@ -21,6 +21,7 @@ class InMemoryDataLogVariable(Writable[T], DataLogVariable[T], Readable[T], Gene
     :param keep: timespan for which to keep the values. Older values will be deleted upon the next `write` to the
                  object.
     """
+
     type: Type[T]
 
     def __init__(self, type_: Type[T], keep: datetime.timedelta):
@@ -37,8 +38,7 @@ class InMemoryDataLogVariable(Writable[T], DataLogVariable[T], Readable[T], Gene
         # We do not need the complicated locking, queuing and flushing from WritableDataLogVariable here, since querying
         # and appending the in-memory log is "atomic" (in the sense of asyncio tasks), i.e. does not include an 'await'
         # statement.
-        tasks = [subscriber._new_log_values_written([entry])
-                 for subscriber in self._data_log_subscribers]
+        tasks = [subscriber._new_log_values_written([entry]) for subscriber in self._data_log_subscribers]
         if len(tasks) == 1:
             await tasks[0]
         else:
@@ -61,8 +61,9 @@ class InMemoryDataLogVariable(Writable[T], DataLogVariable[T], Readable[T], Gene
     def subscribe_data_log(self, subscriber: LiveDataLogView) -> None:
         self._data_log_subscribers.append(subscriber)
 
-    async def retrieve_log(self, start_time: datetime.datetime, end_time: datetime.datetime,
-                           include_previous: bool = False) -> List[Tuple[datetime.datetime, T]]:
+    async def retrieve_log(
+        self, start_time: datetime.datetime, end_time: datetime.datetime, include_previous: bool = False
+    ) -> List[Tuple[datetime.datetime, T]]:
         iterator = iter(enumerate(self.data))
         try:
             start_index = next(i for i, (ts, _v) in iterator if ts >= start_time)
@@ -73,7 +74,7 @@ class InMemoryDataLogVariable(Writable[T], DataLogVariable[T], Readable[T], Gene
                 return []
         if self.data[start_index][0] >= end_time:
             if include_previous and self.data:
-                return self.data[start_index:start_index+1]
+                return self.data[start_index : start_index + 1]
             else:
                 return []
         if include_previous and start_index > 0:

--- a/shc/interfaces/knx.py
+++ b/shc/interfaces/knx.py
@@ -36,6 +36,7 @@ class KNXHVACMode(enum.Enum):
 
     The value mapping corresponds to KNX' native value encoding of this datatype.
     """
+
     AUTO = 0
     COMFORT = 1
     STANDBY = 2
@@ -49,6 +50,7 @@ class KNXUpDown(enum.Enum):
 
     Values of this type can also be used as bool values, using the native KNX value mapping (to datapoint type 1.001).
     """
+
     UP = False
     DOWN = True
 
@@ -64,6 +66,7 @@ class KNXControlDimming(NamedTuple):
     :param increase: True: Increase dimmer brightness / lower blinds; False: Decrese dimmer brightness / raise blinds
     :param step_exponent: 0: Break dimmming action; 1-7 define step size = 2^(1-stepcode)
     """
+
     increase: bool
     step_exponent: int
 
@@ -97,27 +100,27 @@ register_converter(datetime.datetime, knxdclient.KNXTime, knxdclient.KNXTime.fro
 
 
 KNXDPTs: Dict[str, Tuple[type, knxdclient.KNXDPT]] = {
-    '1': (bool, knxdclient.KNXDPT.BOOLEAN),
-    '1.008': (KNXUpDown, knxdclient.KNXDPT.BOOLEAN),
-    '3': (KNXControlDimming, knxdclient.KNXDPT.BOOLEAN_UINT3),
-    '4': (str, knxdclient.KNXDPT.CHAR),
-    '5': (int, knxdclient.KNXDPT.UINT8),
-    '5.001': (datatypes.RangeUInt8, knxdclient.KNXDPT.UINT8),
-    '5.003': (datatypes.AngleUInt8, knxdclient.KNXDPT.UINT8),
-    '5.004': (datatypes.RangeInt0To100, knxdclient.KNXDPT.UINT8),
-    '6': (int, knxdclient.KNXDPT.INT8),
-    '7': (int, knxdclient.KNXDPT.UINT16),
-    '8': (int, knxdclient.KNXDPT.INT16),
-    '9': (float, knxdclient.KNXDPT.FLOAT16),
-    '10': (knxdclient.KNXTime, knxdclient.KNXDPT.TIME),
-    '11': (datetime.date, knxdclient.KNXDPT.DATE),
-    '12': (int, knxdclient.KNXDPT.UINT32),
-    '13': (int, knxdclient.KNXDPT.INT32),
-    '14': (float, knxdclient.KNXDPT.FLOAT32),
-    '16': (str, knxdclient.KNXDPT.STRING),
-    '17': (int, knxdclient.KNXDPT.SCENE_NUMBER),
-    '19': (datetime.datetime, knxdclient.KNXDPT.DATE_TIME),
-    '20.102': (KNXHVACMode, knxdclient.KNXDPT.ENUM8),
+    "1": (bool, knxdclient.KNXDPT.BOOLEAN),
+    "1.008": (KNXUpDown, knxdclient.KNXDPT.BOOLEAN),
+    "3": (KNXControlDimming, knxdclient.KNXDPT.BOOLEAN_UINT3),
+    "4": (str, knxdclient.KNXDPT.CHAR),
+    "5": (int, knxdclient.KNXDPT.UINT8),
+    "5.001": (datatypes.RangeUInt8, knxdclient.KNXDPT.UINT8),
+    "5.003": (datatypes.AngleUInt8, knxdclient.KNXDPT.UINT8),
+    "5.004": (datatypes.RangeInt0To100, knxdclient.KNXDPT.UINT8),
+    "6": (int, knxdclient.KNXDPT.INT8),
+    "7": (int, knxdclient.KNXDPT.UINT16),
+    "8": (int, knxdclient.KNXDPT.INT16),
+    "9": (float, knxdclient.KNXDPT.FLOAT16),
+    "10": (knxdclient.KNXTime, knxdclient.KNXDPT.TIME),
+    "11": (datetime.date, knxdclient.KNXDPT.DATE),
+    "12": (int, knxdclient.KNXDPT.UINT32),
+    "13": (int, knxdclient.KNXDPT.INT32),
+    "14": (float, knxdclient.KNXDPT.FLOAT32),
+    "16": (str, knxdclient.KNXDPT.STRING),
+    "17": (int, knxdclient.KNXDPT.SCENE_NUMBER),
+    "19": (datetime.datetime, knxdclient.KNXDPT.DATE_TIME),
+    "20.102": (KNXHVACMode, knxdclient.KNXDPT.ENUM8),
 }
 
 
@@ -149,8 +152,16 @@ class KNXConnector(SupervisedClientInterface):
         `auto_reconnect` option). Otherwise (default), the first connection attempt on startup is not retried and will
         shutdown the SHC application on failure, even if `auto_reconnect` is True.
     """
-    def __init__(self, host: str = 'localhost', port: int = 6720, sock: Optional[str] = None,
-                 auto_reconnect: bool = True, read_init_after_reconnect: bool = True, failsafe_start: bool = False):
+
+    def __init__(
+        self,
+        host: str = "localhost",
+        port: int = 6720,
+        sock: Optional[str] = None,
+        auto_reconnect: bool = True,
+        read_init_after_reconnect: bool = True,
+        failsafe_start: bool = False,
+    ):
         super().__init__(auto_reconnect, failsafe_start)
         self.backoff_base = 5
         self.host = host
@@ -263,8 +274,11 @@ class KNXConnector(SupervisedClientInterface):
         if addr in self.groups:
             group_var = self.groups[addr]
             if group_var.dpt != dpt:
-                raise ValueError("KNX Datapoint Type conflict: Group Variable {} has been created with type {} before"
-                                 .format(group_var.addr, group_var.dpt))
+                raise ValueError(
+                    "KNX Datapoint Type conflict: Group Variable {} has been created with type {} before".format(
+                        group_var.addr, group_var.dpt
+                    )
+                )
         else:
             group_var = KNXGroupVar(self, addr, dpt)
             self.groups[addr] = group_var
@@ -273,8 +287,9 @@ class KNXConnector(SupervisedClientInterface):
         return group_var
 
     async def _send_init_requests(self):
-        await asyncio.gather(*(self.knx.group_write(addr, knxdclient.KNXDAPDUType.READ, 0)
-                               for addr in self.init_request_groups))
+        await asyncio.gather(
+            *(self.knx.group_write(addr, knxdclient.KNXDAPDUType.READ, 0) for addr in self.init_request_groups)
+        )
 
     def _dispatch_telegram(self, packet: knxdclient.ReceivedGroupAPDU) -> None:
         if packet.payload.type is knxdclient.KNXDAPDUType.READ:

--- a/shc/interfaces/ping.py
+++ b/shc/interfaces/ping.py
@@ -16,7 +16,7 @@ import re
 from shc.base import Subscribable
 from shc.timer import Every
 
-WINDOWS = os.name == 'nt'
+WINDOWS = os.name == "nt"
 
 
 class Ping(Subscribable[bool]):
@@ -35,11 +35,17 @@ class Ping(Subscribable[bool]):
     :param timeout: The timeout for each individual ECHO request in seconds, passed to `ping` via the `-W` argument
         (resp. `-w` on Windows)
     """
-    type = bool
-    RE_WIN_PING_TTL = re.compile(rb'TTL=\d+\s*\n')
 
-    def __init__(self, address: str, interval: datetime.timedelta = datetime.timedelta(minutes=5), number: int = 5,
-                 timeout: float = 1.0):
+    type = bool
+    RE_WIN_PING_TTL = re.compile(rb"TTL=\d+\s*\n")
+
+    def __init__(
+        self,
+        address: str,
+        interval: datetime.timedelta = datetime.timedelta(minutes=5),
+        number: int = 5,
+        timeout: float = 1.0,
+    ):
         super().__init__()
         self.address = address
         self.number = number
@@ -49,10 +55,10 @@ class Ping(Subscribable[bool]):
 
     async def _exec(self, _v, _o) -> None:
         ping_process = await asyncio.create_subprocess_exec(
-            'ping',
-            '-c' if not WINDOWS else '-n',
+            "ping",
+            "-c" if not WINDOWS else "-n",
             str(self.number),
-            '-W' if not WINDOWS else '-w',
+            "-W" if not WINDOWS else "-w",
             str(self.timeout) if not WINDOWS else str(round(self.timeout * 1000)),
             self.address,
             stdout=asyncio.subprocess.PIPE,

--- a/shc/interfaces/system_monitoring.py
+++ b/shc/interfaces/system_monitoring.py
@@ -52,9 +52,16 @@ class EventLoopMonitor(SubscribableStatusInterface):
     :ivar lag: *readable* and *subscribable* connector, representing and publishing the current call delay (maximum
         within the sample interval)
     """
-    def __init__(self, interval: float = 5.0, num_aggr_samples: int = 60,
-                 lag_warning: float = 0.005, lag_error: float = 0.02,
-                 tasks_warning: int = 1000, tasks_error: int = 10000):
+
+    def __init__(
+        self,
+        interval: float = 5.0,
+        num_aggr_samples: int = 60,
+        lag_warning: float = 0.005,
+        lag_error: float = 0.02,
+        tasks_warning: int = 1000,
+        tasks_error: int = 10000,
+    ):
         super().__init__()
         self.interval = interval
         self.num_aggr_samples = num_aggr_samples
@@ -101,11 +108,16 @@ class EventLoopMonitor(SubscribableStatusInterface):
         warning = lag_max >= self.lag_warning or tasks_max >= self.tasks_warning
         error = lag_max >= self.lag_error or tasks_max >= self.tasks_error
         self._status_connector.update_status(
-            (ServiceStatus.UNKNOWN if len(self._samples) == 0
-             else ServiceStatus.CRITICAL if error
-             else ServiceStatus.WARNING if warning
-             else ServiceStatus.OK),
-            ""
+            (
+                ServiceStatus.UNKNOWN
+                if len(self._samples) == 0
+                else ServiceStatus.CRITICAL
+                if error
+                else ServiceStatus.WARNING
+                if warning
+                else ServiceStatus.OK
+            ),
+            "",
         )
         self.tasks.set_generated_value(tasks_max)
         self.lag.set_generated_value(lag_max)

--- a/shc/misc.py
+++ b/shc/misc.py
@@ -36,6 +36,7 @@ class PeriodicReader(Readable[T], Subscribable[T], Generic[T]):
     :param interval: The interval in which the object's `.read()` coroutine is called and the result is published, e.g.
         ``datetime.timedelta(seconds=15)``.
     """
+
     def __init__(self, wrapped: Readable[T], interval: datetime.timedelta):
         self.type = wrapped.type
         super().__init__()
@@ -75,6 +76,7 @@ class TwoWayPipe(ConnectableWrapper[T], Generic[T]):
     :param type_: The `type` of the values to be forwarded. This is used as the `type` of the two pipe-end *connectable*
         objects.
     """
+
     def __init__(self, type_: Type[T]):
         self.type = type_
         self.left = _PipeEnd(type_)
@@ -135,6 +137,7 @@ class BreakableSubscription(Subscribable[T], Generic[T]):
     :param wrapped: The Subscribable object to be wrapped
     :param control: The Readable control object
     """
+
     _synchronous_publishing = True
 
     def __init__(self, wrapped: Subscribable[T], control: Readable[bool]):
@@ -184,20 +187,25 @@ class Hysteresis(Subscribable[bool], Readable[bool]):
         the first value outside of the bounds is received. Attention: If `inverted` is True, the initial value is
         inverted, too.
     """
+
     type = bool
 
-    def __init__(self, wrapped: Subscribable[T], lower: T, upper: T, inverted: bool = False,
-                 initial_value: bool = False):
+    def __init__(
+        self, wrapped: Subscribable[T], lower: T, upper: T, inverted: bool = False, initial_value: bool = False
+    ):
         super().__init__()
         wrapped.trigger(self._new_value, synchronous=True)
         self._value = initial_value  #: Current output value (uninverted)
         if not isinstance(lower, wrapped.type) or not isinstance(upper, wrapped.type):
-            raise TypeError("'lower' and 'upper' must be instances of the wrapped Subscribable's type, which is {}"
-                            .format(wrapped.type.__name__))
+            raise TypeError(
+                "'lower' and 'upper' must be instances of the wrapped Subscribable's type, which is {}".format(
+                    wrapped.type.__name__
+                )
+            )
         self.lower = lower
         self.upper = upper
         if lower > upper:  # type: ignore  # To defined that T is comparable, we need to use Protocols from Python 3.8
-            raise ValueError('Lower bound of hysteresis must be lower than upper bound.')
+            raise ValueError("Lower bound of hysteresis must be lower than upper bound.")
         self.inverted = inverted
 
     async def _new_value(self, value: T, origin: List[Any]) -> None:
@@ -238,14 +246,16 @@ class FadeStepAdapter(Subscribable[RangeFloat1], Reading[RangeFloat1]):
     :param wrapped: The Subscribable object which shall be wrapped to apply its published FadeStep values to connected
         objects
     """
+
     type = RangeFloat1
     is_reading_optional = False
 
     def __init__(self, wrapped: Subscribable[FadeStep]):
         super().__init__()
         if not issubclass(wrapped.type, FadeStep):
-            raise TypeError("First Parameter to `FadeStepAdapter` must be a Subscribable object with value type "
-                            "`FadeStep`")
+            raise TypeError(
+                "First Parameter to `FadeStepAdapter` must be a Subscribable object with value type " "`FadeStep`"
+            )
         wrapped.trigger(self._update, synchronous=True)
 
     async def _update(self, value: FadeStep, origin: List[Any]) -> None:
@@ -298,6 +308,7 @@ class UpdateExchange(Subscribable[T], Writable[T], Generic[T]):
     *UpdateExchange*. In contrast to *Variable*'s fields, the *UpdateExchangeField* objects are not *Writable*; only the
     *UpdateExchange* itself can receive value updates.
     """
+
     def __init__(self, type_: Type[T]):
         self.type = type_
         super().__init__()
@@ -316,8 +327,10 @@ class UpdateExchange(Subscribable[T], Writable[T], Generic[T]):
 
     def field(self, name: str) -> "_UpdateExchangeField":
         if not issubclass(self.type, tuple) or not self.type.__annotations__:
-            raise TypeError(f"{self.type.__name__} is not a NamedTuple, but VariableField.field() only works with "
-                            f"NamedTuple-typed VariableFields.")
+            raise TypeError(
+                f"{self.type.__name__} is not a NamedTuple, but VariableField.field() only works with "
+                f"NamedTuple-typed VariableFields."
+            )
         return self._fields[name]
 
 
@@ -341,7 +354,8 @@ class _UpdateExchangeField(Subscribable[T], Generic[T]):
         if not issubclass(self.type, tuple) or not self.type.__annotations__:
             raise TypeError(
                 f"{self.type.__name__} is not a NamedTuple, but VariableField.field() only works with "
-                f"NamedTuple-typed VariableFields.")
+                f"NamedTuple-typed VariableFields."
+            )
         return self._fields[name]
 
     async def _recursive_publish(self, new_value: T, origin: List[Any]):
@@ -363,6 +377,7 @@ class SimpleInputConnector(Reading[T], Writable[T], Generic[T]):
         objects, make sure to pass the `origin` along when publishing these value updates and to return from this
         coroutine only as soon as the subsequent value updates have been published/written.
     """
+
     is_reading_optional = False
 
     def __init__(self, type_: Type[T], callback: Optional[Callable[[List[Any]], Awaitable[None]]] = None):

--- a/shc/supervisor.py
+++ b/shc/supervisor.py
@@ -34,6 +34,7 @@ class ServiceCriticality(enum.Enum):
     """
     Enum of possible criticality values of interfaces.
     """
+
     INFO = 0
     WARNING = 1
     CRITICAL = 2
@@ -49,6 +50,7 @@ class AbstractInterface(metaclass=abc.ABCMeta):
 
     If an interface inherits from this base class, it is automatically registered for startup via :func:`main`.
     """
+
     def __init__(self):
         register_interface(self)
 
@@ -120,6 +122,7 @@ class ServiceStatus(enum.Enum):
     """
     Enum of possible service status, derived from Nagios/Icinga status.
     """
+
     OK = 0
     WARNING = 1
     CRITICAL = 2
@@ -133,6 +136,7 @@ class InterfaceStatus(NamedTuple):
     Contains the overall interface status (:attr:`status`), a human readable :attr:`message`, typically describing the
     current status, especially the error if any.
     """
+
     status: ServiceStatus = ServiceStatus.OK  #: Overall status of the interface.
     message: str = ""  #: A textual description of the error. E.g. an error message, if status != ServiceStatus.OK
 
@@ -190,8 +194,9 @@ async def run():
 
 async def stop():
     logger.info("Shutting down interfaces ...")
-    await asyncio.gather(*(interface.stop() for interface in _REGISTERED_INTERFACES), timer_supervisor.stop(),
-                         return_exceptions=True)
+    await asyncio.gather(
+        *(interface.stop() for interface in _REGISTERED_INTERFACES), timer_supervisor.stop(), return_exceptions=True
+    )
     _SHC_STOPPED.set()
 
 

--- a/shc/timer.py
+++ b/shc/timer.py
@@ -35,6 +35,7 @@ class _TimerSupervisor:
 
     Should be used as a singleton instance.
     """
+
     def __init__(self):
         self.supervised_timers: List[_AbstractScheduleTimer] = []
         self.timer_tasks: List[asyncio.Task] = []
@@ -75,7 +76,7 @@ async def _logarithmic_sleep(target: datetime.datetime):
             await asyncio.sleep(diff / 2)
 
 
-def _random_time(maximum_offset: Optional[datetime.timedelta], random_function: str = 'uniform') -> datetime.timedelta:
+def _random_time(maximum_offset: Optional[datetime.timedelta], random_function: str = "uniform") -> datetime.timedelta:
     """
     Generate a random timedelta within a given range.
 
@@ -88,9 +89,9 @@ def _random_time(maximum_offset: Optional[datetime.timedelta], random_function: 
     """
     if not maximum_offset:
         return datetime.timedelta()
-    if random_function == 'uniform':
+    if random_function == "uniform":
         random_value = random.uniform(-1, 1)
-    elif random_function == 'gauss':
+    elif random_function == "gauss":
         random_value = random.gauss(0, 0.5)
     else:
         raise ValueError("Unsupported random function '{}'".format(random_function))
@@ -111,6 +112,7 @@ class _AbstractScheduleTimer(Subscribable[None], metaclass=abc.ABCMeta):
 
     :ivar:`last_execution`: Timestamp of the last execution. May be used by the *_next_execution* method.
     """
+
     type = type(None)
 
     def __init__(self):
@@ -157,9 +159,15 @@ class Every(_AbstractScheduleTimer):
     :param random_function: Identifier of a random distribution function to be used for calculating the `random`
         offset. See :func:`_random_time`'s documentation for supported values.
     """
-    def __init__(self, delta: datetime.timedelta, align: bool = True,
-                 offset: datetime.timedelta = datetime.timedelta(), random: Optional[datetime.timedelta] = None,
-                 random_function: str = 'uniform'):
+
+    def __init__(
+        self,
+        delta: datetime.timedelta,
+        align: bool = True,
+        offset: datetime.timedelta = datetime.timedelta(),
+        random: Optional[datetime.timedelta] = None,
+        random_function: str = "uniform",
+    ):
         super().__init__()
         self.delta = delta
         self.align = align
@@ -172,8 +180,8 @@ class Every(_AbstractScheduleTimer):
             delta_seconds = self.delta.total_seconds()
             now_timestamp = datetime.datetime.now().timestamp()
             next_execution = datetime.datetime.fromtimestamp(
-                (math.floor(now_timestamp / delta_seconds) + 1) * delta_seconds)\
-                .astimezone()
+                (math.floor(now_timestamp / delta_seconds) + 1) * delta_seconds
+            ).astimezone()
         else:
             if self.last_execution is None:
                 next_execution = datetime.datetime.now().astimezone()
@@ -203,8 +211,13 @@ class Once(_AbstractScheduleTimer):
     :param random_function: Identifier of a random distribution function to be used for calculating the `random`
         offset. See :func:`_random_time`'s documentation for supported values.
     """
-    def __init__(self, offset: datetime.timedelta = datetime.timedelta(), random: Optional[datetime.timedelta] = None,
-                 random_function: str = 'uniform'):
+
+    def __init__(
+        self,
+        offset: datetime.timedelta = datetime.timedelta(),
+        random: Optional[datetime.timedelta] = None,
+        random_function: str = "uniform",
+    ):
         super().__init__()
         self.offset = offset
         self.random = random
@@ -234,6 +247,7 @@ class EveryNth(int):
 
     E.g. ``month=EveryNth(2)`` equals ``month=[1,3,5,7,9,11]``, ``hour=EveryNth(6) equals hour=[0,6,12,18]``
     """
+
     pass
 
 
@@ -272,18 +286,21 @@ class At(_AbstractScheduleTimer):
     :param random_function: Identifier of a random distribution function to be used for calculating the `random`
         offset. See :func:`_random_time`'s documentation for supported values.
     """
-    def __init__(self,
-                 year: ValSpec = None,
-                 month: ValSpec = None,
-                 day: ValSpec = None,
-                 weeknum: ValSpec = None,
-                 weekday: ValSpec = None,
-                 hour: ValSpec = 0,
-                 minute: ValSpec = 0,
-                 second: ValSpec = 0,
-                 millis: ValSpec = 0,
-                 random: Optional[datetime.timedelta] = None,
-                 random_function: str = 'uniform'):
+
+    def __init__(
+        self,
+        year: ValSpec = None,
+        month: ValSpec = None,
+        day: ValSpec = None,
+        weeknum: ValSpec = None,
+        weekday: ValSpec = None,
+        hour: ValSpec = 0,
+        minute: ValSpec = 0,
+        second: ValSpec = 0,
+        millis: ValSpec = 0,
+        random: Optional[datetime.timedelta] = None,
+        random_function: str = "uniform",
+    ):
         super().__init__()
         if weekday is None and weeknum is None:
             self.spec = (year, month, day, hour, minute, second, millis)
@@ -292,8 +309,10 @@ class At(_AbstractScheduleTimer):
             self.spec = (year, weeknum, weekday, hour, minute, second, millis)
             self.week_mode = True
         else:
-            raise ValueError("At-Timer cannot constrain month/day and week/weekday at the same time. Either month and "
-                             "day or weeknum and weekday must be None.")
+            raise ValueError(
+                "At-Timer cannot constrain month/day and week/weekday at the same time. Either month and "
+                "day or weeknum and weekday must be None."
+            )
         self.random = random
         self.random_function = random_function
 
@@ -326,12 +345,21 @@ class At(_AbstractScheduleTimer):
             elif i == 2 and self.week_mode:
                 return 7
             else:
-                return (datetime.date(val[0] + (1 if val[1] == 12 else 0), 1 if val[1] == 12 else val[1] + 1, 1)
-                        - datetime.timedelta(days=1)).day
+                return (
+                    datetime.date(val[0] + (1 if val[1] == 12 else 0), 1 if val[1] == 12 else val[1] + 1, 1)
+                    - datetime.timedelta(days=1)
+                ).day
 
         if self.week_mode:
-            val = [now.isocalendar()[0], now.isocalendar()[1], now.isocalendar()[2], now.hour, now.minute, now.second,
-                   round(now.microsecond / 1000)]
+            val = [
+                now.isocalendar()[0],
+                now.isocalendar()[1],
+                now.isocalendar()[2],
+                now.hour,
+                now.minute,
+                now.second,
+                round(now.microsecond / 1000),
+            ]
         else:
             val = [now.year, now.month, now.day, now.hour, now.minute, now.second, round(now.microsecond / 1000)]
 
@@ -372,10 +400,12 @@ class At(_AbstractScheduleTimer):
         if self.week_mode:
             # Unfortunately, the fromisocalendar() function has only been added in Python 3.8:
             # val_date = datetime.date.fromisocalendar(val[0], val[1], val[2])
-            val_date = datetime.datetime.strptime("{}-W{}-1".format(val[0], val[1]), '%G-W%V-%u') \
-                       + datetime.timedelta(days=val[2]-1)
-            result = datetime.datetime(val_date.year, val_date.month, val_date.day, val[3], val[4], val[5],
-                                       val[6] * 1000).astimezone()
+            val_date = datetime.datetime.strptime("{}-W{}-1".format(val[0], val[1]), "%G-W%V-%u") + datetime.timedelta(
+                days=val[2] - 1
+            )
+            result = datetime.datetime(
+                val_date.year, val_date.month, val_date.day, val[3], val[4], val[5], val[6] * 1000
+            ).astimezone()
         else:
             result = datetime.datetime(val[0], val[1], val[2], val[3], val[4], val[5], val[6] * 1000).astimezone()
         return result + _random_time(self.random, self.random_function)
@@ -444,6 +474,7 @@ class _DelayedBool(Subscribable[bool], Readable[bool], metaclass=abc.ABCMeta):
     * :class:`TPulse`: Each True value triggers a True pulse of exactly ``delay`` length, but only if no pulse is
         currently active (i.e. the current value is False; a pulse is not re-triggerable).
     """
+
     type = bool
 
     def __init__(self, wrapped: Subscribable[bool], delay: datetime.timedelta):
@@ -493,6 +524,7 @@ class TOn(_DelayedBool):
     :param wrapped: The *Subscribable* object to be wrapped for delaying its value
     :param delay: The power-up delay time. E.g. `datetime.timedelta(seconds=5)`
     """
+
     async def _update(self, value: bool, origin: List[Any]):
         if value and self._change_task is None:
             self._change_task = asyncio.create_task(self._set_delayed(True, origin))
@@ -521,6 +553,7 @@ class TOff(_DelayedBool):
     :param wrapped: The *Subscribable* object to be wrapped for delaying its value
     :param delay: The turn-off delay time. E.g. `datetime.timedelta(seconds=5)`
     """
+
     async def _update(self, value: bool, origin: List[Any]):
         if not value and self._change_task is None:
             self._change_task = asyncio.create_task(self._set_delayed(False, origin))
@@ -550,6 +583,7 @@ class TOnOff(_DelayedBool):
     :param wrapped: The *Subscribable* object to be wrapped for delaying its value
     :param delay: The delay time. E.g. `datetime.timedelta(seconds=5)`
     """
+
     async def _update(self, value: bool, origin: List[Any]):
         if value == self._value and self._change_task is None:
             return
@@ -573,6 +607,7 @@ class TPulse(_DelayedBool):
     :param wrapped: The *Subscribable* object to be wrapped for delaying its value
     :param delay: The pulse length. E.g. `datetime.timedelta(seconds=5)`
     """
+
     def __init__(self, wrapped: Subscribable[bool], delay: datetime.timedelta):
         super().__init__(wrapped, delay)
         self._prev_value = False
@@ -598,6 +633,7 @@ class Delay(Subscribable[T], Readable[T], Generic[T]):
         the `wrapped` object (and passed the delay period). If not given, :meth:`read` raises an
         :class:`shc.base.UninitializedError` in this case.
     """
+
     def __init__(self, wrapped: Subscribable[T], delay: datetime.timedelta, initial_value: Optional[T] = None):
         self.type = wrapped.type
         super().__init__()
@@ -659,10 +695,16 @@ class TimerSwitch(Subscribable[bool], Readable[bool]):
         `duration` is used, a random timedelta between ``-duration_random`` and ``+duration_random`` will be added to
         each individual 'on' period.
     """
+
     type = bool
 
-    def __init__(self, on: Iterable[Subscribable], off: Optional[Iterable[Subscribable]] = None,
-                 duration: Optional[datetime.timedelta] = None, duration_random: Optional[datetime.timedelta] = None):
+    def __init__(
+        self,
+        on: Iterable[Subscribable],
+        off: Optional[Iterable[Subscribable]] = None,
+        duration: Optional[datetime.timedelta] = None,
+        duration_random: Optional[datetime.timedelta] = None,
+    ):
         super().__init__()
         if not off and duration is None:
             raise ValueError("Either 'off' timer specs or a 'duration' must be specified")
@@ -699,8 +741,9 @@ class TimerSwitch(Subscribable[bool], Readable[bool]):
 
     async def _delayed_off(self, origin) -> None:
         assert self.duration is not None
-        await _logarithmic_sleep(datetime.datetime.now().astimezone() + self.duration
-                                 + _random_time(self.duration_random))
+        await _logarithmic_sleep(
+            datetime.datetime.now().astimezone() + self.duration + _random_time(self.duration_random)
+        )
         await self._off(False, origin)
 
     async def read(self) -> bool:
@@ -721,6 +764,7 @@ class RateLimitedSubscription(Subscribable[T], Generic[T]):
     :param wrapped: The Subscribable object to be wrapped
     :param min_interval: The minimal allowed interval between published values in seconds
     """
+
     def __init__(self, wrapped: Subscribable[T], min_interval: float):
         self.type = wrapped.type
         super().__init__()
@@ -800,10 +844,17 @@ class AbstractRamp(Readable[T], Subscribable[T], Reading[T], Writable[T], Generi
         republished immediately. If the value is `True`, the ramp generator is enabled. If no object is given, the ramp
         generator is always on.
     """
+
     is_reading_optional = False
 
-    def __init__(self, type_: Type[T], ramp_duration: datetime.timedelta, dynamic_duration: bool = True,
-                 max_frequency: float = 25.0, enable_ramp: Optional[Readable[bool]] = None):
+    def __init__(
+        self,
+        type_: Type[T],
+        ramp_duration: datetime.timedelta,
+        dynamic_duration: bool = True,
+        max_frequency: float = 25.0,
+        enable_ramp: Optional[Readable[bool]] = None,
+    ):
         self.type = type_
         super().__init__()
         self.ramp_duration = ramp_duration
@@ -968,7 +1019,7 @@ class AbstractRamp(Readable[T], Subscribable[T], Reading[T], Writable[T], Generi
         pass
 
 
-IntRampT = TypeVar('IntRampT', int, RangeUInt8, RangeInt0To100)
+IntRampT = TypeVar("IntRampT", int, RangeUInt8, RangeInt0To100)
 
 
 class IntRamp(AbstractRamp[IntRampT], Generic[IntRampT]):
@@ -981,10 +1032,14 @@ class IntRamp(AbstractRamp[IntRampT], Generic[IntRampT]):
         super().__init__(type_, *args, **kwargs)  # type: ignore  # Mypy does not understand that type_ *is*  FloatRampT
 
     def _calculate_ramp(self, begin: IntRampT, target: IntRampT) -> Tuple[float, int]:
-        diff = abs(target-begin)
-        height = (diff/255 if issubclass(self.type, RangeUInt8) else
-                  diff/100 if issubclass(self.type, RangeInt0To100) else
-                  1.0)
+        diff = abs(target - begin)
+        height = (
+            diff / 255
+            if issubclass(self.type, RangeUInt8)
+            else diff / 100
+            if issubclass(self.type, RangeInt0To100)
+            else 1.0
+        )
         return height, diff
 
     def _init_ramp(self, begin: IntRampT, target: IntRampT, num_steps: int) -> None:
@@ -995,14 +1050,14 @@ class IntRamp(AbstractRamp[IntRampT], Generic[IntRampT]):
         return self.type(round(self._begin + self._diff * step))
 
 
-FloatRampT = TypeVar('FloatRampT', float, RangeFloat1)
+FloatRampT = TypeVar("FloatRampT", float, RangeFloat1)
 
 
 class AbstractFloatRamp(AbstractRamp[FloatRampT], Generic[FloatRampT]):
     def _calculate_ramp(self, begin: FloatRampT, target: FloatRampT) -> Tuple[float, int]:
-        diff = abs(target-begin)
-        height = diff/1.0 if issubclass(self.type, RangeFloat1) else 1.0
-        return height, 2**64-1
+        diff = abs(target - begin)
+        height = diff / 1.0 if issubclass(self.type, RangeFloat1) else 1.0
+        return height, 2**64 - 1
 
     def _init_ramp(self, begin: FloatRampT, target: FloatRampT, num_steps: int) -> None:
         self._begin: FloatRampT = begin
@@ -1029,27 +1084,29 @@ class FadeStepRamp(AbstractFloatRamp[RangeFloat1]):
 
 
 def _normalize_hsv_ramp(begin: HSVFloat1, target: HSVFloat1) -> Tuple[HSVFloat1, HSVFloat1]:
-    return begin._replace(hue=begin.hue if begin.saturation != 0 else target.hue,
-                          saturation=begin.saturation if begin.value != 0 else target.saturation), \
-           target._replace(hue=target.hue if target.saturation != 0 else begin.hue,
-                           saturation=target.saturation if target.value != 0 else begin.saturation)
+    return begin._replace(
+        hue=begin.hue if begin.saturation != 0 else target.hue,
+        saturation=begin.saturation if begin.value != 0 else target.saturation,
+    ), target._replace(
+        hue=target.hue if target.saturation != 0 else begin.hue,
+        saturation=target.saturation if target.value != 0 else begin.saturation,
+    )
 
 
 def _hsv_diff(begin: HSVFloat1, target: HSVFloat1) -> Tuple[float, float, float]:
     return (
-        ((target.hue - begin.hue) % 1
-         if abs((target.hue - begin.hue) % 1) < 0.5
-         else -((begin.hue - target.hue) % 1)
-         ),
+        ((target.hue - begin.hue) % 1 if abs((target.hue - begin.hue) % 1) < 0.5 else -((begin.hue - target.hue) % 1)),
         (target.saturation - begin.saturation),
-        (target.value - begin.value)
+        (target.value - begin.value),
     )
 
 
 def _hsv_step(begin: HSVFloat1, diff: Tuple[float, float, float], step: int) -> HSVFloat1:
-    return HSVFloat1(RangeFloat1((begin.hue + diff[0] * step) % 1.0),
-                     RangeFloat1(begin.saturation + diff[1] * step),
-                     RangeFloat1(begin.value + diff[2] * step))
+    return HSVFloat1(
+        RangeFloat1((begin.hue + diff[0] * step) % 1.0),
+        RangeFloat1(begin.saturation + diff[1] * step),
+        RangeFloat1(begin.value + diff[2] * step),
+    )
 
 
 class HSVRamp(AbstractRamp[HSVFloat1]):
@@ -1061,11 +1118,11 @@ class HSVRamp(AbstractRamp[HSVFloat1]):
     def _calculate_ramp(self, begin: HSVFloat1, target: HSVFloat1) -> Tuple[float, int]:
         diff = _hsv_diff(begin, target)
         height = max(abs(diff[0] * 2), abs(diff[1]), abs(diff[2]))
-        return height, 2**64-1
+        return height, 2**64 - 1
 
     def _init_ramp(self, begin: HSVFloat1, target: HSVFloat1, num_steps: int) -> None:
         self._begin = begin
-        self._diff: Tuple[float, float, float] = tuple(v/num_steps for v in _hsv_diff(begin, target))  # type: ignore
+        self._diff: Tuple[float, float, float] = tuple(v / num_steps for v in _hsv_diff(begin, target))  # type: ignore
 
     def _next_step(self, step: int) -> HSVFloat1:
         return _hsv_step(self._begin, self._diff, step)
@@ -1078,19 +1135,21 @@ class RGBHSVRamp(AbstractRamp[RGBUInt8]):
             wrapped.trigger(self.ramp_to, synchronous=True)
 
     def _calculate_ramp(self, begin: RGBUInt8, target: RGBUInt8) -> Tuple[float, int]:
-        begin_hsv, target_hsv = _normalize_hsv_ramp(HSVFloat1.from_rgb(begin.as_float()),
-                                                    HSVFloat1.from_rgb(target.as_float()))
+        begin_hsv, target_hsv = _normalize_hsv_ramp(
+            HSVFloat1.from_rgb(begin.as_float()), HSVFloat1.from_rgb(target.as_float())
+        )
         diff = _hsv_diff(begin_hsv, target_hsv)
         height = max(abs(diff[0] * 2), abs(diff[1]), abs(diff[2]))
-        max_steps = max(2*abs(b-t) for b, t in zip(begin, target))  # rough estimation
+        max_steps = max(2 * abs(b - t) for b, t in zip(begin, target))  # rough estimation
         return height, max_steps
 
     def _init_ramp(self, begin: RGBUInt8, target: RGBUInt8, num_steps: int) -> None:
-        begin_hsv, target_hsv = _normalize_hsv_ramp(HSVFloat1.from_rgb(begin.as_float()),
-                                                    HSVFloat1.from_rgb(target.as_float()))
+        begin_hsv, target_hsv = _normalize_hsv_ramp(
+            HSVFloat1.from_rgb(begin.as_float()), HSVFloat1.from_rgb(target.as_float())
+        )
         self._hsv_begin = begin_hsv
         hsv_diff = _hsv_diff(begin_hsv, target_hsv)
-        self._hsv_diff: Tuple[float, float, float] = tuple(v/num_steps for v in hsv_diff)  # type: ignore
+        self._hsv_diff: Tuple[float, float, float] = tuple(v / num_steps for v in hsv_diff)  # type: ignore
 
     def _next_step(self, step: int) -> RGBUInt8:
         return RGBUInt8.from_float(_hsv_step(self._hsv_begin, self._hsv_diff, step).as_rgb())
@@ -1103,23 +1162,27 @@ class RGBWHSVRamp(AbstractRamp[RGBWUInt8]):
             wrapped.trigger(self.ramp_to, synchronous=True)
 
     def _calculate_ramp(self, begin: RGBWUInt8, target: RGBWUInt8) -> Tuple[float, int]:
-        begin_hsv, target_hsv = _normalize_hsv_ramp(HSVFloat1.from_rgb(begin.rgb.as_float()),
-                                                    HSVFloat1.from_rgb(target.rgb.as_float()))
+        begin_hsv, target_hsv = _normalize_hsv_ramp(
+            HSVFloat1.from_rgb(begin.rgb.as_float()), HSVFloat1.from_rgb(target.rgb.as_float())
+        )
         hsv_diff = _hsv_diff(begin_hsv, target_hsv)
         w_diff = abs(target.white - begin.white)
         height = max(abs(hsv_diff[0] * 2), abs(hsv_diff[1]), abs(hsv_diff[2]), w_diff / 255)
-        max_steps = max(*(2*abs(b-t) for b, t in zip(begin.rgb, target.rgb)), w_diff)  # rough estimation
+        max_steps = max(*(2 * abs(b - t) for b, t in zip(begin.rgb, target.rgb)), w_diff)  # rough estimation
         return height, max_steps
 
     def _init_ramp(self, begin: RGBWUInt8, target: RGBWUInt8, num_steps: int) -> None:
         self._w_begin: int = begin.white
         self._w_diff: float = (target.white - begin.white) / num_steps
-        begin_hsv, target_hsv = _normalize_hsv_ramp(HSVFloat1.from_rgb(begin.rgb.as_float()),
-                                                    HSVFloat1.from_rgb(target.rgb.as_float()))
+        begin_hsv, target_hsv = _normalize_hsv_ramp(
+            HSVFloat1.from_rgb(begin.rgb.as_float()), HSVFloat1.from_rgb(target.rgb.as_float())
+        )
         self._hsv_begin = begin_hsv
         hsv_diff = _hsv_diff(begin_hsv, target_hsv)
-        self._hsv_diff: Tuple[float, float, float] = tuple(v/num_steps for v in hsv_diff)  # type: ignore
+        self._hsv_diff: Tuple[float, float, float] = tuple(v / num_steps for v in hsv_diff)  # type: ignore
 
     def _next_step(self, step: int) -> RGBWUInt8:
-        return RGBWUInt8(RGBUInt8.from_float(_hsv_step(self._hsv_begin, self._hsv_diff, step).as_rgb()),
-                         RangeUInt8(round(self._w_begin + self._w_diff * step)))
+        return RGBWUInt8(
+            RGBUInt8.from_float(_hsv_step(self._hsv_begin, self._hsv_diff, step).as_rgb()),
+            RangeUInt8(round(self._w_begin + self._w_diff * step)),
+        )

--- a/shc/util/check_shc.py
+++ b/shc/util/check_shc.py
@@ -18,6 +18,7 @@ Only monitoring metrics (ignoring the overall server state):
     check_shc.py -u http://shc-host:80/base_path -s -m interface_name.metric_name<50<100
 
 """
+
 import argparse
 import enum
 import json
@@ -31,7 +32,7 @@ def main() -> None:
     args = get_arg_parser().parse_args()
 
     # Do request
-    request = urllib.request.Request(f"{args.url[0]}/monitoring", None, {'Accept': "application/json"})
+    request = urllib.request.Request(f"{args.url[0]}/monitoring", None, {"Accept": "application/json"})
     try:
         response = urllib.request.urlopen(request, timeout=5.0)
         status = response.status
@@ -54,27 +55,32 @@ def main() -> None:
     except Exception as e:
         exit_with_report(ServiceStatus.UNKNOWN, f"HTTP Response from SHC web server was no correctly encoded JSON: {e}")
 
-    if 'interfaces' not in data or 'status' not in data:
+    if "interfaces" not in data or "status" not in data:
         invalid_result()
 
     # If requested to check a single interface:
     if args.interface is not None:
         interface_name = args.interface[0]
         if interface_name not in data["interfaces"]:
-            exit_with_report(ServiceStatus.UNKNOWN,
-                             f"Interface '{interface_name} is not present in monitoring data returned from SHC server")
+            exit_with_report(
+                ServiceStatus.UNKNOWN,
+                f"Interface '{interface_name} is not present in monitoring data returned from SHC server",
+            )
 
-        interface_data = data['interfaces'][interface_name]
-        status = interface_data['status']
-        exit_with_report(ServiceStatus(status),
-                         f"Interface status: {ServiceStatus(interface_data['status']).to_string()}; "
-                         + interface_data['message'],
-                         "")
+        interface_data = data["interfaces"][interface_name]
+        status = interface_data["status"]
+        exit_with_report(
+            ServiceStatus(status),
+            f"Interface status: {ServiceStatus(interface_data['status']).to_string()}; " + interface_data["message"],
+            "",
+        )
     else:
-        status = data['status']
-        exit_with_report(ServiceStatus(status),
-                         f"Overall SHC server status: {ServiceStatus(data['status']).to_string()}",
-                         "",)
+        status = data["status"]
+        exit_with_report(
+            ServiceStatus(status),
+            f"Overall SHC server status: {ServiceStatus(data['status']).to_string()}",
+            "",
+        )
 
 
 def invalid_result() -> NoReturn:
@@ -87,7 +93,8 @@ def exit_with_report(status: "ServiceStatus", message: str = "", long_message: s
 
 
 def get_arg_parser() -> argparse.ArgumentParser:
-    arg_parser = argparse.ArgumentParser(description="""
+    arg_parser = argparse.ArgumentParser(
+        description="""
     Nagios-compatible monitoring plugin for monitoring an SHC server via the monitoring endpoint of the web interface
 
     By default, the script checks the HTTP reachability of the server and the overall status reported by the server
@@ -96,12 +103,17 @@ def get_arg_parser() -> argparse.ArgumentParser:
 
     If the --interface option is given, the status of the specific SHC interface is reported instead, or UNKNOWN if the
     server is not reachable or the interface does not exist.
-    """)
+    """
+    )
     arg_parser.add_argument("-u", "--url", nargs=1, required=True, help="Base URL of the SHC web server")
-    arg_parser.add_argument("-i", "--interface", nargs=1,
-                            help="The display_name of a specific SHC interface in the monitoring data of the SHC "
-                                 "server. If given, the status of this interface is evaluated, instead of the overall "
-                                 "server state.")
+    arg_parser.add_argument(
+        "-i",
+        "--interface",
+        nargs=1,
+        help="The display_name of a specific SHC interface in the monitoring data of the SHC "
+        "server. If given, the status of this interface is evaluated, instead of the overall "
+        "server state.",
+    )
     return arg_parser
 
 

--- a/shc/web/__init__.py
+++ b/shc/web/__init__.py
@@ -1,2 +1,1 @@
-
 from .interface import WebServer

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -643,7 +643,7 @@ class DisplayButton(WebDisplayDatapoint[T], AbstractButton, Generic[T]):
 
     def __init__(
         self,
-        value: T = True,
+        value: T = cast(T, True),
         label: Union[str, Markup] = "",  # type: ignore
         color: str = "blue",
         outline: bool = False,

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -643,7 +643,7 @@ class DisplayButton(WebDisplayDatapoint[T], AbstractButton, Generic[T]):
 
     def __init__(
         self,
-        value: T = cast(T, True),
+        value: T = True,  # type: ignore
         label: Union[str, Markup] = "",  # type: ignore
         color: str = "blue",
         outline: bool = False,

--- a/shc/web/widgets.py
+++ b/shc/web/widgets.py
@@ -23,7 +23,6 @@ different pages). To create two or more similar and synchronized widgets/buttons
 settings and `connect` both of them to the same :class:`shc.Variable`.
 """
 
-
 import abc
 import enum
 import itertools
@@ -47,28 +46,46 @@ from typing import (
 import markupsafe
 from markupsafe import Markup
 
-from .interface import WebPageItem, WebDisplayDatapoint, WebActionDatapoint, jinja_env, WebConnectorContainer, \
-    WebUIConnector, WebPage, WebServer
+from .interface import (
+    WebPageItem,
+    WebDisplayDatapoint,
+    WebActionDatapoint,
+    jinja_env,
+    WebConnectorContainer,
+    WebUIConnector,
+    WebPage,
+    WebServer,
+)
 from ..base import T, ConnectableWrapper, Connectable
 from ..conversion import SHCJsonEncoder
 from ..datatypes import RangeFloat1, RGBUInt8
 
 
 __all__ = [
-    'icon',
-    'Switch',
-    'Select', 'EnumSelect',
-    'ButtonGroup', 'ValueListButtonGroup', 'EnumButtonGroup',
-    'ToggleButton', 'ValueButton', 'DisplayButton', 'StatelessButton',
-    'TextDisplay', 'TextInput',
-    'Slider', 'MinMaxButtonSlider',
-    'HideRowBox', 'HideRow',
-    'ColorChoser',
-    'ImageMap', 'ImageMapLabel',
+    "icon",
+    "Switch",
+    "Select",
+    "EnumSelect",
+    "ButtonGroup",
+    "ValueListButtonGroup",
+    "EnumButtonGroup",
+    "ToggleButton",
+    "ValueButton",
+    "DisplayButton",
+    "StatelessButton",
+    "TextDisplay",
+    "TextInput",
+    "Slider",
+    "MinMaxButtonSlider",
+    "HideRowBox",
+    "HideRow",
+    "ColorChoser",
+    "ImageMap",
+    "ImageMapLabel",
 ]
 
 
-def icon(icon_name: str, label: str = '') -> Markup:
+def icon(icon_name: str, label: str = "") -> Markup:
     """
     Create HTML markup for a Fontawesome/Semantic UI icon, to be used in PageItem labels, button labels, etc.
 
@@ -101,8 +118,14 @@ class Switch(WebDisplayDatapoint[bool], WebActionDatapoint[bool], WebPageItem):
         `[False]`, only switching off must be confirmed. Defaults to `[False, True]`, i.e. every change must be
         confirmed.
     """
-    def __init__(self, label: Union[str, Markup], color: str = '', confirm_message: str = '',
-                 confirm_values: Iterable[bool] = (False, True)):
+
+    def __init__(
+        self,
+        label: Union[str, Markup],
+        color: str = "",
+        confirm_message: str = "",
+        confirm_values: Iterable[bool] = (False, True),
+    ):
         self.type = bool
         super().__init__()
         self.label = label
@@ -111,9 +134,13 @@ class Switch(WebDisplayDatapoint[bool], WebActionDatapoint[bool], WebPageItem):
         self.confirm = confirm_values if confirm_message else ()
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/switch.htm').render_async(
-            id=id(self), label=self.label, color=self.color,
-            confirm_csv_int=",".join(str(int(v)) for v in self.confirm), confirm_message=self.confirm_message)
+        return await jinja_env.get_template("widgets/switch.htm").render_async(
+            id=id(self),
+            label=self.label,
+            color=self.color,
+            confirm_csv_int=",".join(str(int(v)) for v in self.confirm),
+            confirm_message=self.confirm_message,
+        )
 
 
 class Select(WebDisplayDatapoint[T], WebActionDatapoint[T], WebPageItem, Generic[T]):
@@ -131,16 +158,19 @@ class Select(WebDisplayDatapoint[T], WebActionDatapoint[T], WebPageItem, Generic
         embedding in HTML) or a :class:`markupsafe.Markup` object, which may contain pre-formattet HTML, e.g.
         produced by :func:`icon`.
     """
-    def __init__(self, options: List[Tuple[T, Union[str, Markup]]], label: str = ''):
+
+    def __init__(self, options: List[Tuple[T, Union[str, Markup]]], label: str = ""):
         self.type = type(options[0][0])
         super().__init__()
         self.options = options
         self.label = label
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/select.htm').render_async(
-            id=id(self), label=self.label, options=[(json.dumps(value, cls=SHCJsonEncoder), label)
-                                                    for value, label in self.options])
+        return await jinja_env.get_template("widgets/select.htm").render_async(
+            id=id(self),
+            label=self.label,
+            options=[(json.dumps(value, cls=SHCJsonEncoder), label) for value, label in self.options],
+        )
 
 
 class EnumSelect(Select):
@@ -153,12 +183,13 @@ class EnumSelect(Select):
         embedding in HTML) or a :class:`markupsafe.Markup` object, which may contain pre-formattet HTML, e.g.
         produced by :func:`icon`.
     """
-    def __init__(self, type_: Type[enum.Enum], label: Union[str, Markup] = ''):
+
+    def __init__(self, type_: Type[enum.Enum], label: Union[str, Markup] = ""):
         values = [(entry, entry.name) for entry in type_]
         super().__init__(values, label)
 
 
-Ti = TypeVar('Ti', int, float, str)
+Ti = TypeVar("Ti", int, float, str)
 
 
 class TextInput(WebDisplayDatapoint[Ti], WebActionDatapoint[Ti], WebPageItem, Generic[Ti]):
@@ -182,8 +213,16 @@ class TextInput(WebDisplayDatapoint[Ti], WebActionDatapoint[Ti], WebPageItem, Ge
     :param input_suffix: A plain string or HTML markup to be appended to the right of the input field, using Semantic
         UI's `labeled inputs <https://fomantic-ui.com/elements/input.html#labeled>`_.
     """
-    def __init__(self, type_: Type[Ti], label: Union[str, Markup] = '', min: Optional[Ti] = None,
-                 max: Optional[Ti] = None, step: Optional[Ti] = None, input_suffix: Union[str, Markup] = ''):
+
+    def __init__(
+        self,
+        type_: Type[Ti],
+        label: Union[str, Markup] = "",
+        min: Optional[Ti] = None,
+        max: Optional[Ti] = None,
+        step: Optional[Ti] = None,
+        input_suffix: Union[str, Markup] = "",
+    ):
         self.type = type_
         super().__init__()
         self.label = label
@@ -199,9 +238,15 @@ class TextInput(WebDisplayDatapoint[Ti], WebActionDatapoint[Ti], WebPageItem, Ge
         return self.type(value)
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/textinput.htm').render_async(
-            id=id(self), label=self.label, type=self.input_type, min=self.min, max=self.max, step=self.step,
-            input_suffix=self.input_suffix)
+        return await jinja_env.get_template("widgets/textinput.htm").render_async(
+            id=id(self),
+            label=self.label,
+            type=self.input_type,
+            min=self.min,
+            max=self.max,
+            step=self.step,
+            input_suffix=self.input_suffix,
+        )
 
 
 class TextDisplay(WebDisplayDatapoint[T], WebPageItem):
@@ -230,21 +275,22 @@ class TextDisplay(WebDisplayDatapoint[T], WebPageItem):
         escaped for embedding in HTML) or a :class:`markupsafe.Markup` object, which may contain pre-formattet HTML,
         e.g. produced by :func:`icon`.
     """
-    def __init__(self, type_: Type[T], format: Union[str, Markup, Callable[[T], Union[str, Markup]]],
-                 label: Union[str, Markup]):
+
+    def __init__(
+        self, type_: Type[T], format: Union[str, Markup, Callable[[T], Union[str, Markup]]], label: Union[str, Markup]
+    ):
         self.type = type_
         super().__init__()
         self.formatter: Callable[[T], Union[str, Markup]] = (
-            (lambda x: format.format(x))
-            if isinstance(format, (str, Markup))
-            else format)
+            (lambda x: format.format(x)) if isinstance(format, (str, Markup)) else format
+        )
         self.label = label
 
     def convert_to_ws_value(self, value: T) -> Any:
         return markupsafe.escape(self.formatter(value))
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/textdisplay.htm').render_async(id=id(self), label=self.label)
+        return await jinja_env.get_template("widgets/textdisplay.htm").render_async(id=id(self), label=self.label)
 
 
 class Slider(WebDisplayDatapoint[RangeFloat1], WebActionDatapoint[RangeFloat1], WebPageItem):
@@ -266,8 +312,14 @@ class Slider(WebDisplayDatapoint[RangeFloat1], WebActionDatapoint[RangeFloat1], 
         independently from `left_button`).  All different kinds of buttons and all layout features of
         :class:`AbstractButton` are supported.
     """
-    def __init__(self, label: Union[str, Markup] = '', color: str = '',
-                 left_button: Optional["AbstractButton"] = None, right_button: Optional["AbstractButton"] = None, ):
+
+    def __init__(
+        self,
+        label: Union[str, Markup] = "",
+        color: str = "",
+        left_button: Optional["AbstractButton"] = None,
+        right_button: Optional["AbstractButton"] = None,
+    ):
         self.type = RangeFloat1
         super().__init__()
         self.label = label
@@ -279,9 +331,13 @@ class Slider(WebDisplayDatapoint[RangeFloat1], WebActionDatapoint[RangeFloat1], 
         return RangeFloat1(float(value))
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/slider.htm').render_async(
-            id=id(self), label=self.label, color=self.color, left_button=self.left_button,
-            right_button=self.right_button)
+        return await jinja_env.get_template("widgets/slider.htm").render_async(
+            id=id(self),
+            label=self.label,
+            color=self.color,
+            left_button=self.left_button,
+            right_button=self.right_button,
+        )
 
 
 class MinMaxButtonSlider(WebPageItem, ConnectableWrapper[RangeFloat1]):
@@ -302,10 +358,11 @@ class MinMaxButtonSlider(WebPageItem, ConnectableWrapper[RangeFloat1]):
         (when hightlighted). Must be one of Semantic UI's predefined slider colors:
         https://fomantic-ui.com/modules/slider.html#colored
     """
-    def __init__(self, label: Union[str, Markup] = '', color: str = ''):
+
+    def __init__(self, label: Union[str, Markup] = "", color: str = ""):
         super().__init__()
-        self.left_button = ValueButton(RangeFloat1(0), icon('circle outline'), color=color or 'black')
-        self.right_button = ValueButton(RangeFloat1(1), icon('circle'), color=color or 'black')
+        self.left_button = ValueButton(RangeFloat1(0), icon("circle outline"), color=color or "black")
+        self.right_button = ValueButton(RangeFloat1(1), icon("circle"), color=color or "black")
         self.slider = Slider(label, color, self.left_button, self.right_button)
 
     async def render(self) -> str:
@@ -314,10 +371,15 @@ class MinMaxButtonSlider(WebPageItem, ConnectableWrapper[RangeFloat1]):
     def get_connectors(self) -> Iterable["WebUIConnector"]:
         return self.slider, self.left_button, self.right_button
 
-    def connect(self, other: "Connectable", send: Optional[bool] = None, receive: Optional[bool] = None,
-                read: Optional[bool] = None, provide: Optional[bool] = None,
-                convert: Union[bool, Tuple[Callable[[RangeFloat1], Any], Callable[[Any], RangeFloat1]]] = False
-                ) -> "MinMaxButtonSlider":
+    def connect(
+        self,
+        other: "Connectable",
+        send: Optional[bool] = None,
+        receive: Optional[bool] = None,
+        read: Optional[bool] = None,
+        provide: Optional[bool] = None,
+        convert: Union[bool, Tuple[Callable[[RangeFloat1], Any], Callable[[Any], RangeFloat1]]] = False,
+    ) -> "MinMaxButtonSlider":
         self.slider.connect(other, send, receive, read, provide, convert)
         self.left_button.connect(other, send, receive, read, provide, convert)
         self.right_button.connect(other, send, receive, read, provide, convert)
@@ -338,6 +400,7 @@ class ButtonGroup(WebPageItem):
         grouped all together, whereas providing multiple lists each list will be grouped together with a small gap
         between each group of button descriptors.
     """
+
     def __init__(
         self,
         label: Union[str, Markup],
@@ -356,8 +419,9 @@ class ButtonGroup(WebPageItem):
         return self.buttons  # type: ignore
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/buttongroup.htm')\
-            .render_async(label=self.label, button_groups=self.button_groups)
+        return await jinja_env.get_template("widgets/buttongroup.htm").render_async(
+            label=self.label, button_groups=self.button_groups
+        )
 
 
 class AbstractButton(metaclass=abc.ABCMeta):
@@ -392,8 +456,9 @@ class AbstractButton(metaclass=abc.ABCMeta):
     :var confirm_message: The message to be shown in the confirm window, when a confirmation is required for an
         interaction with this button.
     """
-    label: Union[str, Markup] = ''
-    color: str = ''
+
+    label: Union[str, Markup] = ""
+    color: str = ""
     stateful: bool = True
     enabled: bool = True
     outline: bool = False
@@ -405,7 +470,7 @@ class AbstractButton(metaclass=abc.ABCMeta):
         return ",".join(str(int(v)) for v in self.confirm)
 
 
-jinja_env.tests['button'] = lambda item: isinstance(item, AbstractButton)
+jinja_env.tests["button"] = lambda item: isinstance(item, AbstractButton)
 
 
 class StatelessButton(WebActionDatapoint[T], AbstractButton, Generic[T]):
@@ -428,10 +493,17 @@ class StatelessButton(WebActionDatapoint[T], AbstractButton, Generic[T]):
         (`Semantic UI basic button <https://fomantic-ui.com/elements/button.html#basic>`_). Since the button has no
         on/off state, this holds all the time.
     """
+
     stateful = False
 
-    def __init__(self, value: T, label: Union[str, Markup] = '', color: str = '', confirm_message: str = '',
-                 outline: bool = False):
+    def __init__(
+        self,
+        value: T,
+        label: Union[str, Markup] = "",
+        color: str = "",
+        confirm_message: str = "",
+        outline: bool = False,
+    ):
         self.type = type(value)
         super().__init__()
         self.value = value
@@ -473,8 +545,15 @@ class ValueButton(WebActionDatapoint[T], WebDisplayDatapoint[T], AbstractButton,
     :param outline: If True, the button is shown with a colored outline in its configured `color` **when not lit up**,
         instead of its grey-ish default appearance.
     """
-    def __init__(self, value: T, label: Union[str, Markup] = '', color: str = 'blue',
-                 confirm_message: str = '', outline: bool = False):
+
+    def __init__(
+        self,
+        value: T,
+        label: Union[str, Markup] = "",
+        color: str = "blue",
+        confirm_message: str = "",
+        outline: bool = False,
+    ):
         self.type = type(value)
         super().__init__()
         self.value = value
@@ -518,8 +597,15 @@ class ToggleButton(WebActionDatapoint[bool], AbstractButton, WebDisplayDatapoint
     :param outline: If True, the button is shown with a colored outline in its configured `color` **in 'off' state**,
         instead of its grey-ish default appearance.
     """
-    def __init__(self, label: Union[str, Markup] = '', color: str = 'blue', confirm_message: str = '',
-                 confirm_values: Iterable[bool] = (False, True), outline: bool = False):
+
+    def __init__(
+        self,
+        label: Union[str, Markup] = "",
+        color: str = "blue",
+        confirm_message: str = "",
+        confirm_values: Iterable[bool] = (False, True),
+        outline: bool = False,
+    ):
         self.type = bool
         super().__init__()
         self.label = label
@@ -552,10 +638,16 @@ class DisplayButton(WebDisplayDatapoint[T], AbstractButton, Generic[T]):
     :param outline: If True, the button is shown with a colored outline in its configured `color` **when not lit up**,
         instead of its grey-ish default appearance.
     """
+
     enabled = False
 
-    def __init__(self, value: T = True,  label: Union[str, Markup] = '',  # type: ignore
-                 color: str = 'blue', outline: bool = False):
+    def __init__(
+        self,
+        value: T = True,
+        label: Union[str, Markup] = "",  # type: ignore
+        color: str = "blue",
+        outline: bool = False,
+    ):
         self.type = type(value)
         super().__init__()
         self.value = value
@@ -581,8 +673,14 @@ class ValueListButtonGroup(ButtonGroup, ConnectableWrapper[T], Generic[T]):
     :param color: A common `color` for all buttons
     :param confirm_message: A common `confirm_message` for all buttons
     """
-    def __init__(self, values: List[Tuple[T, Union[str, Markup]]], label: Union[str, Markup],
-                 color: str = 'blue', confirm_message: str = ''):
+
+    def __init__(
+        self,
+        values: List[Tuple[T, Union[str, Markup]]],
+        label: Union[str, Markup],
+        color: str = "blue",
+        confirm_message: str = "",
+    ):
         buttons = [ValueButton(value=v[0], label=v[1], color=color, confirm_message=confirm_message) for v in values]
         super().__init__(label, buttons)
 
@@ -607,8 +705,10 @@ class EnumButtonGroup(ValueListButtonGroup):
     :param color: A common `color` for all buttons
     :param confirm_message: A common `confirm_message` for all buttons
     """
-    def __init__(self, type_: Type[enum.Enum], label: Union[str, Markup], color: str = 'blue',
-                 confirm_message: str = ''):
+
+    def __init__(
+        self, type_: Type[enum.Enum], label: Union[str, Markup], color: str = "blue", confirm_message: str = ""
+    ):
         values = [(entry, entry.name) for entry in type_]
         super().__init__(values, label, color, confirm_message)
 
@@ -620,6 +720,7 @@ class HideRowBox(WebPageItem):
     The HideRowBox is a *WebPageItem*, so it can be added to web pages, and takes a list of :class:`HideRow` which are
     dynamically shown or hidden.
     """
+
     def __init__(self, rows: List["HideRow"]):
         self.rows = rows
 
@@ -627,7 +728,7 @@ class HideRowBox(WebPageItem):
         return itertools.chain.from_iterable(row.get_connectors() for row in self.rows)
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/hiderowbox.htm').render_async(rows=self.rows)
+        return await jinja_env.get_template("widgets/hiderowbox.htm").render_async(rows=self.rows)
 
 
 class HideRow(WebDisplayDatapoint[bool], WebConnectorContainer):
@@ -651,8 +752,13 @@ class HideRow(WebDisplayDatapoint[bool], WebConnectorContainer):
                    side of the *HideRow* when displayed.
     :param color: The background color of the *HideRow* when displayed. Must be one Fomantic UI's color names
     """
-    def __init__(self, label: Union[str, Markup], button: Optional[AbstractButton] = None,
-                 color: str = 'blue',):
+
+    def __init__(
+        self,
+        label: Union[str, Markup],
+        button: Optional[AbstractButton] = None,
+        color: str = "blue",
+    ):
         self.type = bool
         super().__init__()
         self.label = label
@@ -673,11 +779,12 @@ class ColorChoser(WebActionDatapoint[RGBUInt8], WebDisplayDatapoint[RGBUInt8], W
     an interactive color chooser widget. It is updated dynamically from *connected* objects and allows the user to
     select a color, which is published by the *ColorChoser* object in SHC.
     """
+
     type = RGBUInt8
 
     async def render(self) -> str:
         # TODO add label
-        return await jinja_env.get_template('widgets/colorchoser.htm').render_async(id=id(self))
+        return await jinja_env.get_template("widgets/colorchoser.htm").render_async(id=id(self))
 
 
 ImageMapItem = Union[AbstractButton, "ImageMapLabel"]
@@ -743,22 +850,33 @@ class ImageMap(WebPageItem):
     :param max_width: If given and not None, defines the maximum width of the background image on large screens in
                       pixels.
     """
-    def __init__(self, image: Union[PathLike, str],
-                 items: Iterable[Union[Tuple[float, float, ImageMapItem],
-                                       Tuple[float, float, ImageMapItem, List[WebPageItem]]]],
-                 max_width: Optional[int] = None):
+
+    def __init__(
+        self,
+        image: Union[PathLike, str],
+        items: Iterable[Union[Tuple[float, float, ImageMapItem], Tuple[float, float, ImageMapItem, List[WebPageItem]]]],
+        max_width: Optional[int] = None,
+    ):
         super().__init__()
         self.image = image
-        self.image_url: str = ''
+        self.image_url: str = ""
         # Allow using external images: If `image` is an absolute URI, simply use it as the img src, instead of trying
         # to serve it via our http server
-        if isinstance(image, str) and '://' in image:
+        if isinstance(image, str) and "://" in image:
             self.image_url = image
 
         self.max_width = max_width
-        self.items: List[Tuple[float, float, ImageMapItem, List[WebPageItem]]]\
-            = [item if len(item) >= 4 else (item[0], item[1], item[2], [],)
-               for item in items]
+        self.items: List[Tuple[float, float, ImageMapItem, List[WebPageItem]]] = [
+            item
+            if len(item) >= 4
+            else (
+                item[0],
+                item[1],
+                item[2],
+                [],
+            )
+            for item in items
+        ]
 
     def register_with_server(self, _page: WebPage, server: WebServer) -> None:
         if not self.image_url:
@@ -771,8 +889,9 @@ class ImageMap(WebPageItem):
             yield from itertools.chain.from_iterable(i.get_connectors() for i in sub_items)
 
     async def render(self) -> str:
-        return await jinja_env.get_template('widgets/imagemap.htm')\
-            .render_async(items=self.items, image_url=self.image_url, max_width=self.max_width)
+        return await jinja_env.get_template("widgets/imagemap.htm").render_async(
+            items=self.items, image_url=self.image_url, max_width=self.max_width
+        )
 
 
 class ImageMapLabel(WebDisplayDatapoint[T]):
@@ -786,4 +905,4 @@ class ImageMapLabel(WebDisplayDatapoint[T]):
         return self.format_string.format(value)
 
 
-jinja_env.tests['imageMapLabel'] = lambda item: isinstance(item, ImageMapLabel)
+jinja_env.tests["imageMapLabel"] = lambda item: isinstance(item, ImageMapLabel)

--- a/test/_helper.py
+++ b/test/_helper.py
@@ -32,10 +32,12 @@ def async_test(f: Callable[..., Awaitable[Any]]) -> Callable[..., Any]:
     """
     Decorator to transform async unittest coroutines into normal test methods
     """
+
     @functools.wraps(f)
     def wrapper(*args, **kwargs):
         loop = asyncio.get_event_loop()
         loop.run_until_complete(f(*args, **kwargs))
+
     return wrapper
 
 
@@ -50,6 +52,7 @@ class AsyncMock(unittest.mock.MagicMock):
     The async calls are passed to the normal call/enter/exit methods of the super class to use its usual builtin
     evaluation/assertion functionality (e.g. :meth:`unittest.mock.NonCallableMock.assert_called_with`).
     """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if not hasattr(self, "__signature__"):
@@ -81,14 +84,19 @@ class ClockMock:
     which inherit from their original pendants. To avoid failing type checks in other tests, the replacement is reverted
     when exiting the patch context.
     """
+
     class NewDate(datetime.date):
         pass
 
     class NewDateTime(datetime.datetime):
         pass
 
-    def __init__(self, start_time: datetime.datetime, overshoot: datetime.timedelta = datetime.timedelta(),
-                 actual_sleep: float = 0.0):
+    def __init__(
+        self,
+        start_time: datetime.datetime,
+        overshoot: datetime.timedelta = datetime.timedelta(),
+        actual_sleep: float = 0.0,
+    ):
         self.current_time = start_time
         self.overshoot = overshoot
         self.actual_sleep = actual_sleep
@@ -194,15 +202,16 @@ class ClockMock:
 
     def __enter__(self) -> "ClockMock":
         import datetime
+
         datetime.date = self.NewDate  # type: ignore
         datetime.datetime = self.NewDateTime  # type: ignore
 
         self.patches = (
-            unittest.mock.patch('time.sleep', new=self.sleep),
-            unittest.mock.patch('asyncio.sleep', new=self.async_sleep),
-            unittest.mock.patch('datetime.datetime.now', new=self.now),
-            unittest.mock.patch('time.time', new=self.time),
-            unittest.mock.patch('datetime.date.today', new=self.today),
+            unittest.mock.patch("time.sleep", new=self.sleep),
+            unittest.mock.patch("asyncio.sleep", new=self.async_sleep),
+            unittest.mock.patch("datetime.datetime.now", new=self.now),
+            unittest.mock.patch("time.time", new=self.time),
+            unittest.mock.patch("datetime.date.today", new=self.today),
         )
         for p in self.patches:
             p.__enter__()
@@ -220,7 +229,7 @@ class ClockMock:
 # Example Connectable objects
 # ###########################
 
-T = TypeVar('T')
+T = TypeVar("T")
 
 
 class ExampleReadable(base.Readable[T], Generic[T]):
@@ -271,7 +280,7 @@ class SimpleIntRepublisher(base.Writable, base.Subscribable):
         await self._publish_and_wait(value, origin)
 
 
-IT = TypeVar('IT', bound=AbstractInterface)
+IT = TypeVar("IT", bound=AbstractInterface)
 
 
 class InterfaceThreadRunner(Generic[IT]):
@@ -302,6 +311,7 @@ class InterfaceThreadRunner(Generic[IT]):
     :param kwargs: keyword arguments to be passed to the interface's constructor
     :raises TimeoutError: When the interface cannot be constructed within 5 seconds.
     """
+
     executor = concurrent.futures.ThreadPoolExecutor()
 
     def __init__(self, interface_class: Type[IT], *args, **kwargs):

--- a/test/interfaces/test_command.py
+++ b/test/interfaces/test_command.py
@@ -1,4 +1,5 @@
 """Test for the command binary interface."""
+
 import unittest
 import unittest.mock
 

--- a/test/interfaces/test_file_persistence.py
+++ b/test/interfaces/test_file_persistence.py
@@ -36,7 +36,6 @@ class FilePersistenceTest(unittest.TestCase):
             runner2 = InterfaceThreadRunner(file_persistence.FilePersistenceStore, Path(tempdir) / "store.json")
             interface2: file_persistence.FilePersistenceStore = runner2.interface
             try:
-
                 conn21 = interface2.connector(float, "conn1")
                 conn22 = interface2.connector(ExampleTupleType, "conn2")
                 conn23 = interface2.connector(int, "conn3")
@@ -52,7 +51,7 @@ class FilePersistenceTest(unittest.TestCase):
     def test_existing_json(self) -> None:
         with tempfile.TemporaryDirectory() as tempdir:
             path = Path(tempdir) / "store.json"
-            with open(path, 'w') as f:
+            with open(path, "w") as f:
                 json.dump({"conn1": 3.14, "conn2": [56, 0.0]}, f)
 
             runner = InterfaceThreadRunner(file_persistence.FilePersistenceStore, Path(tempdir) / "store.json")
@@ -88,7 +87,7 @@ class FilePersistenceTest(unittest.TestCase):
                 # Since we abandon 1 line per cycle (see below), this should trigger at least one full rewrite
                 for i in range(1, 11):
                     for j in range(1, 11):
-                        n = i*10+j
+                        n = i * 10 + j
                         runner.run_coro(conn1.write(n, [self]))
                         # String grows more than our buffer in each cycle → new line each cycle
                         text = "0123456789ab" * n

--- a/test/interfaces/test_in_memory_data_logging.py
+++ b/test/interfaces/test_in_memory_data_logging.py
@@ -13,9 +13,10 @@ class InMemoryTest(AbstractLoggingTest):
     do_write_tests = True
     do_subscribe_tests = True
 
-    async def _create_log_variable_with_data(self, type_: Type[T], data: Iterable[Tuple[datetime.datetime, T]]) \
-            -> shc.data_logging.DataLogVariable[T]:
-        var = shc.interfaces.in_memory_data_logging.InMemoryDataLogVariable(type_, datetime.timedelta(days=1000*365))
+    async def _create_log_variable_with_data(
+        self, type_: Type[T], data: Iterable[Tuple[datetime.datetime, T]]
+    ) -> shc.data_logging.DataLogVariable[T]:
+        var = shc.interfaces.in_memory_data_logging.InMemoryDataLogVariable(type_, datetime.timedelta(days=1000 * 365))
         var.data = list(data)
         return var
 

--- a/test/interfaces/test_midi.py
+++ b/test/interfaces/test_midi.py
@@ -34,7 +34,7 @@ class MIDITest(unittest.TestCase):
 @unittest.skipUnless(mido_backend_available, "mido MIDI backend is not available: {}".format(mido_backend_error))
 class MIDIInputTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.port_name = 'TestOutPort' + self.id().split('.')[-1]
+        self.port_name = "TestOutPort" + self.id().split(".")[-1]
         self.dummy_port = mido.open_output(self.port_name, virtual=True)
 
         self.interface_runner = InterfaceThreadRunner(shc.interfaces.midi.MidiInterface, self.port_name, None)
@@ -49,17 +49,16 @@ class MIDIInputTest(unittest.TestCase):
         var2 = self.interface.note_velocity(7)
         var3 = self.interface.control_change(1)
 
-        with unittest.mock.patch.object(var1, '_publish') as publish_mock1, \
-             unittest.mock.patch.object(var2, '_publish') as publish_mock2, \
-             unittest.mock.patch.object(var3, '_publish') as publish_mock3:
-
+        with unittest.mock.patch.object(var1, "_publish") as publish_mock1, unittest.mock.patch.object(
+            var2, "_publish"
+        ) as publish_mock2, unittest.mock.patch.object(var3, "_publish") as publish_mock3:
             self.interface_runner.start()
             time.sleep(0.05)
 
             # Things to be ignored
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=42, velocity=20))
-            self.dummy_port.send(mido.Message('control_change', channel=0, control=42, value=0))
-            self.dummy_port.send(mido.Message('aftertouch', channel=0, value=18))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=42, velocity=20))
+            self.dummy_port.send(mido.Message("control_change", channel=0, control=42, value=0))
+            self.dummy_port.send(mido.Message("aftertouch", channel=0, value=18))
             time.sleep(0.05)
 
             publish_mock1.assert_not_called()
@@ -67,8 +66,8 @@ class MIDIInputTest(unittest.TestCase):
             publish_mock3.assert_not_called()
 
             # Note on
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=5, velocity=20))
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=7, velocity=20))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=5, velocity=20))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=7, velocity=20))
             time.sleep(0.05)
 
             publish_mock1.assert_called_once_with(True, unittest.mock.ANY)
@@ -78,8 +77,8 @@ class MIDIInputTest(unittest.TestCase):
             # Note off
             publish_mock1.reset_mock()
             publish_mock2.reset_mock()
-            self.dummy_port.send(mido.Message('note_off', channel=0, note=5, velocity=40))
-            self.dummy_port.send(mido.Message('note_off', channel=0, note=7, velocity=40))
+            self.dummy_port.send(mido.Message("note_off", channel=0, note=5, velocity=40))
+            self.dummy_port.send(mido.Message("note_off", channel=0, note=7, velocity=40))
             time.sleep(0.05)
 
             publish_mock1.assert_called_once_with(False, unittest.mock.ANY)
@@ -89,7 +88,7 @@ class MIDIInputTest(unittest.TestCase):
             # Control change
             publish_mock1.reset_mock()
             publish_mock2.reset_mock()
-            self.dummy_port.send(mido.Message('control_change', channel=0, control=1, value=42))
+            self.dummy_port.send(mido.Message("control_change", channel=0, control=1, value=42))
             time.sleep(0.05)
 
             publish_mock1.assert_not_called()
@@ -99,18 +98,17 @@ class MIDIInputTest(unittest.TestCase):
     def test_emulated_toggle(self) -> None:
         var1 = self.interface.note_on_off(5, emulate_toggle=True)
 
-        with unittest.mock.patch.object(var1, '_publish') as publish_mock:
-
+        with unittest.mock.patch.object(var1, "_publish") as publish_mock:
             self.interface_runner.start()
             time.sleep(0.05)
 
             # Toggle on
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=5, velocity=127))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=5, velocity=127))
             time.sleep(0.05)
             publish_mock.assert_called_once_with(True, unittest.mock.ANY)
 
             publish_mock.reset_mock()
-            self.dummy_port.send(mido.Message('note_off', channel=0, note=5, velocity=0))
+            self.dummy_port.send(mido.Message("note_off", channel=0, note=5, velocity=0))
             time.sleep(0.05)
             publish_mock.assert_called_once_with(True, unittest.mock.ANY)
 
@@ -118,12 +116,12 @@ class MIDIInputTest(unittest.TestCase):
 
             # Toggle off
             publish_mock.reset_mock()
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=5, velocity=127))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=5, velocity=127))
             time.sleep(0.05)
             publish_mock.assert_called_once_with(False, unittest.mock.ANY)
 
             publish_mock.reset_mock()
-            self.dummy_port.send(mido.Message('note_off', channel=0, note=5, velocity=0))
+            self.dummy_port.send(mido.Message("note_off", channel=0, note=5, velocity=0))
             time.sleep(0.05)
             publish_mock.assert_called_once_with(False, unittest.mock.ANY)
 
@@ -132,7 +130,7 @@ class MIDIInputTest(unittest.TestCase):
 
             # Toggle off again
             publish_mock.reset_mock()
-            self.dummy_port.send(mido.Message('note_on', channel=0, note=5, velocity=127))
+            self.dummy_port.send(mido.Message("note_on", channel=0, note=5, velocity=127))
             time.sleep(0.05)
             publish_mock.assert_called_once_with(False, unittest.mock.ANY)
 
@@ -140,12 +138,13 @@ class MIDIInputTest(unittest.TestCase):
 @unittest.skipUnless(mido_backend_available, "mido MIDI backend is not available: {}".format(mido_backend_error))
 class MIDIOutputTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.port_name = 'TestInPort' + self.id().split('.')[-1]
+        self.port_name = "TestInPort" + self.id().split(".")[-1]
         self.callback = unittest.mock.Mock()
         self.dummy_port = mido.open_input(self.port_name, virtual=True, callback=self.callback)
 
-        self.interface_runner = InterfaceThreadRunner(shc.interfaces.midi.MidiInterface, None, self.port_name,
-                                                      send_channel=9)
+        self.interface_runner = InterfaceThreadRunner(
+            shc.interfaces.midi.MidiInterface, None, self.port_name, send_channel=9
+        )
         self.interface = self.interface_runner.interface
 
     def tearDown(self) -> None:

--- a/test/interfaces/test_mqtt.py
+++ b/test/interfaces/test_mqtt.py
@@ -21,8 +21,8 @@ class MQTTClientTest(unittest.TestCase):
     def setUp(self) -> None:
         self.client_runner = InterfaceThreadRunner(shc.interfaces.mqtt.MQTTClientInterface, "localhost", 42883)
         self.client = self.client_runner.interface
-        self.broker_config_file = Path(__file__).parent.parent / 'assets' / 'mosquitto.conf'
-        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", '-c', str(self.broker_config_file)])
+        self.broker_config_file = Path(__file__).parent.parent / "assets" / "mosquitto.conf"
+        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", "-c", str(self.broker_config_file)])
         time.sleep(0.25)
 
     def tearDown(self) -> None:
@@ -39,19 +39,19 @@ class MQTTClientTest(unittest.TestCase):
     async def test_subscribe(self) -> None:
         await self._send_retained_test_message()
 
-        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw('test/topic'))
-        target_raw2 = ExampleWritable(bytes).connect(self.client.topic_raw('test/another/topic'))
-        target_str = ExampleWritable(str).connect(self.client.topic_string('test/topic', 'test/#'))
-        target_int = ExampleWritable(int).connect(self.client.topic_json(int, 'test/topic'))
+        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw("test/topic"))
+        target_raw2 = ExampleWritable(bytes).connect(self.client.topic_raw("test/another/topic"))
+        target_str = ExampleWritable(str).connect(self.client.topic_string("test/topic", "test/#"))
+        target_int = ExampleWritable(int).connect(self.client.topic_json(int, "test/topic"))
 
         self.client_runner.start()
 
         await asyncio.sleep(0.50)
 
         # Due to the double-subscription to test/topic, they may be called multiple times
-        target_raw._write.assert_called_with(b'42', unittest.mock.ANY)
+        target_raw._write.assert_called_with(b"42", unittest.mock.ANY)
         target_raw2._write.assert_not_called()
-        target_str._write.assert_called_with('42', unittest.mock.ANY)
+        target_str._write.assert_called_with("42", unittest.mock.ANY)
         target_int._write.assert_called_with(42, unittest.mock.ANY)
         target_raw._write.reset_mock()
         target_str._write.reset_mock()
@@ -62,8 +62,8 @@ class MQTTClientTest(unittest.TestCase):
 
         await asyncio.sleep(0.05)
 
-        target_raw._write.assert_called_once_with(b'56', unittest.mock.ANY)
-        target_str._write.assert_called_once_with('56', unittest.mock.ANY)
+        target_raw._write.assert_called_once_with(b"56", unittest.mock.ANY)
+        target_str._write.assert_called_once_with("56", unittest.mock.ANY)
         target_int._write.assert_called_once_with(56, unittest.mock.ANY)
         target_raw._write.reset_mock()
         target_str._write.reset_mock()
@@ -75,7 +75,7 @@ class MQTTClientTest(unittest.TestCase):
         await asyncio.sleep(0.05)
 
         target_raw._write.assert_not_called()
-        target_str._write.assert_called_once_with('21', unittest.mock.ANY)
+        target_str._write.assert_called_once_with("21", unittest.mock.ANY)
         target_raw._write.assert_not_called()
 
     @async_test
@@ -84,7 +84,7 @@ class MQTTClientTest(unittest.TestCase):
 
         async def _task() -> None:
             async with aiomqtt.Client("localhost", 42883, identifier="TestClient") as c:
-                await c.subscribe('#')
+                await c.subscribe("#")
                 async for msg in c.messages:
                     MESSAGES.append(msg)
 
@@ -92,9 +92,9 @@ class MQTTClientTest(unittest.TestCase):
         await asyncio.sleep(0.1)
 
         try:
-            conn_raw = self.client.topic_raw('test/topic', qos=2)
-            conn_str = self.client.topic_string('test/another/topic', 'test/another/#', retain=True)
-            conn_json = self.client.topic_json(str, 'test/topic', force_mqtt_subscription=True)
+            conn_raw = self.client.topic_raw("test/topic", qos=2)
+            conn_str = self.client.topic_string("test/another/topic", "test/another/#", retain=True)
+            conn_json = self.client.topic_json(str, "test/topic", force_mqtt_subscription=True)
             target_str = ExampleWritable(str).connect(conn_str)
 
             self.client_runner.start()
@@ -104,22 +104,22 @@ class MQTTClientTest(unittest.TestCase):
             await asyncio.sleep(0.1)
             self.assertEqual(1, len(MESSAGES))
             self.assertEqual(b'"500"', MESSAGES[-1].payload)
-            self.assertEqual('test/topic', str(MESSAGES[-1].topic))
+            self.assertEqual("test/topic", str(MESSAGES[-1].topic))
 
-            await self.client_runner.run_coro_async(conn_str.write('a test with »«', [self]))
+            await self.client_runner.run_coro_async(conn_str.write("a test with »«", [self]))
             # Due to the local subscriber, write() should wait until the message has been received
-            target_str._write.assert_called_once_with('a test with »«', [self, conn_str])
+            target_str._write.assert_called_once_with("a test with »«", [self, conn_str])
             await asyncio.sleep(0.01)
             self.assertEqual(2, len(MESSAGES))
-            self.assertEqual('a test with »«'.encode('utf-8'), MESSAGES[-1].payload)
-            self.assertEqual('test/another/topic', str(MESSAGES[-1].topic))
+            self.assertEqual("a test with »«".encode("utf-8"), MESSAGES[-1].payload)
+            self.assertEqual("test/another/topic", str(MESSAGES[-1].topic))
 
-            await self.client_runner.run_coro_async(conn_json.write('text', [self]))
+            await self.client_runner.run_coro_async(conn_json.write("text", [self]))
             # Du to the forced subscription, write() should wait until the message has been received
             await asyncio.sleep(0.01)
             self.assertEqual(3, len(MESSAGES))
             self.assertEqual(b'"text"', MESSAGES[-1].payload)
-            self.assertEqual('test/topic', str(MESSAGES[-1].topic))
+            self.assertEqual("test/topic", str(MESSAGES[-1].topic))
 
         finally:
             task.cancel()
@@ -129,11 +129,11 @@ class MQTTClientTest(unittest.TestCase):
     def test_reconnect(self) -> None:
         asyncio.get_event_loop().run_until_complete(self._send_retained_test_message())
 
-        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw('test/topic'))
+        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw("test/topic"))
         self.client_runner.start()
         # We cannot use ClockMock here, since it does not support asyncio.wait()
         time.sleep(0.05)
-        target_raw._write.assert_called_once_with(b'42', unittest.mock.ANY)
+        target_raw._write.assert_called_once_with(b"42", unittest.mock.ANY)
         target_raw._write.reset_mock()
 
         with self.assertLogs("shc.interfaces._helper", logging.ERROR) as ctx:
@@ -150,22 +150,22 @@ class MQTTClientTest(unittest.TestCase):
         # self.assertIn("Connection refused", ctx.output[0])
 
         # Restart server
-        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", '-c', str(self.broker_config_file)])
+        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", "-c", str(self.broker_config_file)])
 
         # Wait for second reconnect attempt
-        with unittest.mock.patch.object(self.client.client, '__aenter__', new=AsyncMock()) as connect_mock:
+        with unittest.mock.patch.object(self.client.client, "__aenter__", new=AsyncMock()) as connect_mock:
             time.sleep(0.8)
             connect_mock.assert_not_called()
 
         asyncio.get_event_loop().run_until_complete(self._send_retained_test_message())
         time.sleep(5)
 
-        target_raw._write.assert_called_once_with(b'42', unittest.mock.ANY)
+        target_raw._write.assert_called_once_with(b"42", unittest.mock.ANY)
 
     def test_initial_reconnect(self) -> None:
         asyncio.get_event_loop().run_until_complete(self._send_retained_test_message())
         self.client.failsafe_start = True
-        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw('test/topic'))
+        target_raw = ExampleWritable(bytes).connect(self.client.topic_raw("test/topic"))
 
         self.broker_process.terminate()
         self.broker_process.wait()
@@ -179,14 +179,14 @@ class MQTTClientTest(unittest.TestCase):
         self.assertIn("Connection refused", ctx.output[0])
 
         # Restart server
-        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", '-c', str(self.broker_config_file)])
+        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", "-c", str(self.broker_config_file)])
         time.sleep(0.25)
         asyncio.get_event_loop().run_until_complete(self._send_retained_test_message())
 
         # wait for reconnect attempt
-        with unittest.mock.patch.object(self.client.client, '__aenter__', new=AsyncMock()) as connect_mock:
+        with unittest.mock.patch.object(self.client.client, "__aenter__", new=AsyncMock()) as connect_mock:
             time.sleep(0.15)
             connect_mock.assert_not_called()
         time.sleep(0.4)
 
-        target_raw._write.assert_called_once_with(b'42', unittest.mock.ANY)
+        target_raw._write.assert_called_once_with(b"42", unittest.mock.ANY)

--- a/test/interfaces/test_ping.py
+++ b/test/interfaces/test_ping.py
@@ -10,7 +10,7 @@ class PingTest(unittest.TestCase):
     @async_test
     async def test_ping(self) -> None:
         timer_mock = ExampleSubscribable(type(None))
-        with unittest.mock.patch('shc.interfaces.ping.Every', return_value=timer_mock):
+        with unittest.mock.patch("shc.interfaces.ping.Every", return_value=timer_mock):
             ping_localhost1 = ping.Ping("localhost", number=3, timeout=0.5)
             ping_localhost2 = ping.Ping("127.0.0.1", number=3, timeout=0.5)
             ping_unreachable = ping.Ping("192.0.2.0", number=3, timeout=0.5)

--- a/test/interfaces/test_pulse.py
+++ b/test/interfaces/test_pulse.py
@@ -487,7 +487,7 @@ load-module module-null-sink sink_name=testsink1
 load-module module-null-sink sink_name=testsink2 channels=6 channel_map=front-left,front-right,rear-left,rear-right,front-center,lfe
 load-module module-null-source source_name=testsource1
 load-module module-null-source source_name=testsource2
-""".encode()
-    )  # noqa: E501
+""".encode()  # noqa: E501
+    )
     proc.stdin.close()
     return Path(pulse_dir), proc

--- a/test/interfaces/test_pulse.py
+++ b/test/interfaces/test_pulse.py
@@ -17,7 +17,7 @@ from .._helper import async_test, InterfaceThreadRunner, ExampleWritable
 
 libpulse_available = False
 try:
-    ctypes.CDLL(ctypes.util.find_library('libpulse') or 'libpulse.so.0')
+    ctypes.CDLL(ctypes.util.find_library("libpulse") or "libpulse.so.0")
     libpulse_available = True
 except OSError:
     pass
@@ -50,7 +50,7 @@ class PulseVolumeTests(unittest.TestCase):
         vol = shc.interfaces.pulse.PulseVolumeRaw([0.1, 0.2, 0.3, 0.4, 0.5, 0.6], [1, 2, 5, 6, 3, 7])
         vol_split = shc.interfaces.pulse.PulseVolumeComponents.from_channels(vol)
         self.assertEqual(vol.map, vol_split.map)
-        self.assertAlmostEqual(1-0.2/0.3, vol_split.balance, places=4)
+        self.assertAlmostEqual(1 - 0.2 / 0.3, vol_split.balance, places=4)
         self.assertAlmostEqual(0.6, vol_split.volume, places=4)
 
         vol2 = vol_split.as_channels()
@@ -73,8 +73,9 @@ class SinkConnectorTests(unittest.TestCase):
         pulse_dir, self.pulse_process = create_dummy_instance()
         time.sleep(0.5)  # let Pulseaudio start
         self.pulse_url = f"unix:{pulse_dir / 'pulse' / 'native'}"
-        self.interface_runner = InterfaceThreadRunner(shc.interfaces.pulse.PulseAudioInterface,
-                                                      pulse_server_socket=self.pulse_url)
+        self.interface_runner = InterfaceThreadRunner(
+            shc.interfaces.pulse.PulseAudioInterface, pulse_server_socket=self.pulse_url
+        )
         self.interface: shc.interfaces.pulse.PulseAudioInterface = self.interface_runner.interface
 
     def tearDown(self) -> None:
@@ -92,8 +93,8 @@ class SinkConnectorTests(unittest.TestCase):
         target3 = ExampleWritable(shc.interfaces.pulse.PulseVolumeRaw).connect(volume_connector3)
 
         # Initialize sink volumes
-        await self._run_pactl('set-sink-volume', 'testsink1', '90%')
-        await self._run_pactl('set-sink-volume', 'testsink2', '100%')
+        await self._run_pactl("set-sink-volume", "testsink1", "90%")
+        await self._run_pactl("set-sink-volume", "testsink2", "100%")
 
         self.interface_runner.start()
 
@@ -108,7 +109,7 @@ class SinkConnectorTests(unittest.TestCase):
         # External volume change to testsink2
         target1._write.reset_mock()
         target2._write.reset_mock()
-        await self._run_pactl('set-sink-volume', 'testsink2', '90%', '80%', '80%', '70%', '90%', '90%')
+        await self._run_pactl("set-sink-volume", "testsink2", "90%", "80%", "80%", "70%", "90%", "90%")
         await asyncio.sleep(0.05)
         target2._write.assert_called_once()
         for v1, v2 in zip([0.9, 0.8, 0.8, 0.7, 0.9, 0.9], target2._write.call_args[0][0].values):
@@ -117,7 +118,7 @@ class SinkConnectorTests(unittest.TestCase):
         target3._write.assert_not_called()
 
         # testsink3 added
-        output = await self._run_pactl('load-module', 'module-null-sink', 'sink_name=testsink3')
+        output = await self._run_pactl("load-module", "module-null-sink", "sink_name=testsink3")
         module_id = int(output)
         await asyncio.sleep(0.05)
         target3._write.assert_called_once()
@@ -125,7 +126,7 @@ class SinkConnectorTests(unittest.TestCase):
             self.assertAlmostEqual(v1, v2, places=4)
 
         # unload testsink3
-        await self._run_pactl('unload-module', str(module_id))
+        await self._run_pactl("unload-module", str(module_id))
         await asyncio.sleep(0.05)
         with self.assertRaises(shc.base.UninitializedError):
             await self.interface_runner.run_coro_async(volume_connector3.read())
@@ -138,7 +139,7 @@ class SinkConnectorTests(unittest.TestCase):
         self.assertEqual([self, volume_connector1], target1._write.call_args[0][1])
         for v1, v2 in zip(value1_new.values, target1._write.call_args[0][0].values):
             self.assertAlmostEqual(v1, v2, places=4)
-        response = (await self._pactl_get_data('sink', 'testsink1'))['Volume']
+        response = (await self._pactl_get_data("sink", "testsink1"))["Volume"]
         self.assertIn("front-left: 52429", response)
         self.assertIn("front-right: 45875", response)
 
@@ -147,7 +148,7 @@ class SinkConnectorTests(unittest.TestCase):
         mute_connector = self.interface.default_sink_muted()
         target = ExampleWritable(bool).connect(mute_connector)
 
-        await self._run_pactl('set-default-sink', 'testsink1')
+        await self._run_pactl("set-default-sink", "testsink1")
 
         self.interface_runner.start()
 
@@ -157,19 +158,19 @@ class SinkConnectorTests(unittest.TestCase):
 
         # External mute change to testsink1
         target._write.reset_mock()
-        await self._run_pactl('set-sink-mute', 'testsink1', 'true')
+        await self._run_pactl("set-sink-mute", "testsink1", "true")
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(True, unittest.mock.ANY)
 
         # Change default sink to testsink2
         target._write.reset_mock()
-        await self._run_pactl('set-default-sink', 'testsink2')
+        await self._run_pactl("set-default-sink", "testsink2")
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(False, unittest.mock.ANY)
 
         # External mute change to testsink1, which should not have an effect
         target._write.reset_mock()
-        await self._run_pactl('set-sink-mute', 'testsink1', 'false')
+        await self._run_pactl("set-sink-mute", "testsink1", "false")
         await asyncio.sleep(0.05)
         target._write.assert_not_called()
 
@@ -178,17 +179,17 @@ class SinkConnectorTests(unittest.TestCase):
         await self.interface_runner.run_coro_async(mute_connector.write(True, [self]))
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(True, [self, mute_connector])
-        self.assertIn("yes", (await self._pactl_get_data('sink', 'testsink2'))['Mute'])
-        self.assertIn("no", (await self._pactl_get_data('sink', 'testsink1'))['Mute'])
+        self.assertIn("yes", (await self._pactl_get_data("sink", "testsink2"))["Mute"])
+        self.assertIn("no", (await self._pactl_get_data("sink", "testsink1"))["Mute"])
 
     @async_test
     async def test_sink_peak_and_state(self) -> None:
-        state_connector = self.interface.sink_running('testsink1')
+        state_connector = self.interface.sink_running("testsink1")
         state_target = ExampleWritable(bool).connect(state_connector)
         peak_connector = self.interface.default_sink_peak_monitor(20)
         peak_target = ExampleWritable(RangeFloat1).connect(peak_connector)
 
-        await self._run_pactl('set-default-sink', 'testsink1')
+        await self._run_pactl("set-default-sink", "testsink1")
 
         self.interface_runner.start()
 
@@ -205,7 +206,8 @@ class SinkConnectorTests(unittest.TestCase):
 
         # start noise playback
         proc = await asyncio.create_subprocess_exec(
-            'paplay', '-s', self.pulse_url, '--raw', '/dev/urandom', env=dict(PATH=os.environ['PATH']))
+            "paplay", "-s", self.pulse_url, "--raw", "/dev/urandom", env=dict(PATH=os.environ["PATH"])
+        )
 
         # Check sink state and sink monitor
         await asyncio.sleep(0.1)
@@ -231,8 +233,8 @@ class SinkConnectorTests(unittest.TestCase):
         target3 = ExampleWritable(shc.interfaces.pulse.PulseVolumeRaw).connect(volume_connector3)
 
         # Initialize source volumes
-        await self._run_pactl('set-source-volume', 'testsource1', '90%')
-        await self._run_pactl('set-source-volume', 'testsource2', '100%')
+        await self._run_pactl("set-source-volume", "testsource1", "90%")
+        await self._run_pactl("set-source-volume", "testsource2", "100%")
 
         self.interface_runner.start()
 
@@ -247,7 +249,7 @@ class SinkConnectorTests(unittest.TestCase):
         # External volume change to testsource2
         target1._write.reset_mock()
         target2._write.reset_mock()
-        await self._run_pactl('set-source-volume', 'testsource2', '90%', '80%')
+        await self._run_pactl("set-source-volume", "testsource2", "90%", "80%")
         await asyncio.sleep(0.05)
         target2._write.assert_called_once()
         for v1, v2 in zip([0.9, 0.8], target2._write.call_args[0][0].values):
@@ -256,7 +258,7 @@ class SinkConnectorTests(unittest.TestCase):
         target3._write.assert_not_called()
 
         # testsource3 added
-        output = await self._run_pactl('load-module', 'module-null-source', 'source_name=testsource3')
+        output = await self._run_pactl("load-module", "module-null-source", "source_name=testsource3")
         module_id = int(output)
         await asyncio.sleep(0.05)
         target3._write.assert_called_once()
@@ -264,7 +266,7 @@ class SinkConnectorTests(unittest.TestCase):
             self.assertAlmostEqual(v1, v2, places=4)
 
         # unload testsource3
-        await self._run_pactl('unload-module', str(module_id))
+        await self._run_pactl("unload-module", str(module_id))
         await asyncio.sleep(0.05)
         with self.assertRaises(shc.base.UninitializedError):
             await self.interface_runner.run_coro_async(volume_connector3.read())
@@ -277,7 +279,7 @@ class SinkConnectorTests(unittest.TestCase):
         self.assertEqual([self, volume_connector1], target1._write.call_args[0][1])
         for v1, v2 in zip(value1_new.values, target1._write.call_args[0][0].values):
             self.assertAlmostEqual(v1, v2, places=4)
-        response = (await self._pactl_get_data('source', 'testsource1'))['Volume']
+        response = (await self._pactl_get_data("source", "testsource1"))["Volume"]
         self.assertIn("front-left: 52429", response)
         self.assertIn("front-right: 45875", response)
 
@@ -286,7 +288,7 @@ class SinkConnectorTests(unittest.TestCase):
         mute_connector = self.interface.default_source_muted()
         target = ExampleWritable(bool).connect(mute_connector)
 
-        await self._run_pactl('set-default-source', 'testsource1')
+        await self._run_pactl("set-default-source", "testsource1")
 
         self.interface_runner.start()
 
@@ -296,19 +298,19 @@ class SinkConnectorTests(unittest.TestCase):
 
         # External mute change to testsource1
         target._write.reset_mock()
-        await self._run_pactl('set-source-mute', 'testsource1', 'true')
+        await self._run_pactl("set-source-mute", "testsource1", "true")
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(True, unittest.mock.ANY)
 
         # Change default source to testsource2
         target._write.reset_mock()
-        await self._run_pactl('set-default-source', 'testsource2')
+        await self._run_pactl("set-default-source", "testsource2")
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(False, unittest.mock.ANY)
 
         # External mute change to testsource1, which should not have an effect
         target._write.reset_mock()
-        await self._run_pactl('set-source-mute', 'testsource1', 'false')
+        await self._run_pactl("set-source-mute", "testsource1", "false")
         await asyncio.sleep(0.05)
         target._write.assert_not_called()
 
@@ -317,16 +319,16 @@ class SinkConnectorTests(unittest.TestCase):
         await self.interface_runner.run_coro_async(mute_connector.write(True, [self]))
         await asyncio.sleep(0.05)
         target._write.assert_called_once_with(True, [self, mute_connector])
-        self.assertIn("yes", (await self._pactl_get_data('source', 'testsource2'))['Mute'])
-        self.assertIn("no", (await self._pactl_get_data('source', 'testsource1'))['Mute'])
+        self.assertIn("yes", (await self._pactl_get_data("source", "testsource2"))["Mute"])
+        self.assertIn("no", (await self._pactl_get_data("source", "testsource1"))["Mute"])
 
     @async_test
     async def test_source_peak(self) -> None:
-        peak_connector = self.interface.source_peak_monitor('testsink1.monitor', 20)
+        peak_connector = self.interface.source_peak_monitor("testsink1.monitor", 20)
         peak_target = ExampleWritable(RangeFloat1).connect(peak_connector)
 
-        await self._run_pactl('set-default-sink', 'testsink1')
-        await self._run_pactl('set-default-source', 'testsink1.monitor')
+        await self._run_pactl("set-default-sink", "testsink1")
+        await self._run_pactl("set-default-source", "testsink1.monitor")
 
         self.interface_runner.start()
 
@@ -339,7 +341,8 @@ class SinkConnectorTests(unittest.TestCase):
 
         # start noise playback to get some readings on the peak monitoring of the monitor source
         proc = await asyncio.create_subprocess_exec(
-            'paplay', '-s', self.pulse_url, '--raw', '/dev/urandom', env=dict(PATH=os.environ['PATH']))
+            "paplay", "-s", self.pulse_url, "--raw", "/dev/urandom", env=dict(PATH=os.environ["PATH"])
+        )
         await asyncio.sleep(0.1)
         self.assertGreater(peak_target._write.call_count, 2)
         self.assertGreater(peak_target._write.call_args[0][0], 0.0)
@@ -350,10 +353,10 @@ class SinkConnectorTests(unittest.TestCase):
 
     @async_test
     async def test_source_state(self) -> None:
-        state_connector = self.interface.source_running('testsource1')
+        state_connector = self.interface.source_running("testsource1")
         state_target = ExampleWritable(bool).connect(state_connector)
 
-        await self._run_pactl('set-default-source', 'testsource1')
+        await self._run_pactl("set-default-source", "testsource1")
 
         self.interface_runner.start()
 
@@ -364,7 +367,8 @@ class SinkConnectorTests(unittest.TestCase):
 
         # start recording from monitor source (to /dev/null)
         proc = await asyncio.create_subprocess_exec(
-            'paplay', '-s', self.pulse_url, '-r', '/dev/null', env=dict(PATH=os.environ['PATH']))
+            "paplay", "-s", self.pulse_url, "-r", "/dev/null", env=dict(PATH=os.environ["PATH"])
+        )
 
         # Check source state and source monitor
         await asyncio.sleep(0.1)
@@ -386,50 +390,52 @@ class SinkConnectorTests(unittest.TestCase):
         default_source_connector = self.interface.default_source_name()
         source_target = ExampleWritable(str).connect(default_source_connector)
 
-        await self._run_pactl('set-default-sink', 'testsink1')
-        await self._run_pactl('set-default-source', 'testsource1')
+        await self._run_pactl("set-default-sink", "testsink1")
+        await self._run_pactl("set-default-source", "testsource1")
 
         self.interface_runner.start()
 
-        sink_target._write.assert_called_with('testsink1', unittest.mock.ANY)
-        source_target._write.assert_called_with('testsource1', unittest.mock.ANY)
+        sink_target._write.assert_called_with("testsink1", unittest.mock.ANY)
+        source_target._write.assert_called_with("testsource1", unittest.mock.ANY)
         value = await self.interface_runner.run_coro_async(default_sink_connector.read())
-        self.assertEqual('testsink1', value)
+        self.assertEqual("testsink1", value)
         value = await self.interface_runner.run_coro_async(default_source_connector.read())
-        self.assertEqual('testsource1', value)
+        self.assertEqual("testsource1", value)
 
         # External change of default sink/source
         sink_target._write.reset_mock()
         source_target._write.reset_mock()
-        await self._run_pactl('set-default-sink', 'testsink2')
+        await self._run_pactl("set-default-sink", "testsink2")
         await asyncio.sleep(0.1)
-        sink_target._write.assert_called_once_with('testsink2', unittest.mock.ANY)
-        await self._run_pactl('set-default-source', 'testsource2')
+        sink_target._write.assert_called_once_with("testsink2", unittest.mock.ANY)
+        await self._run_pactl("set-default-source", "testsource2")
         await asyncio.sleep(0.1)
-        source_target._write.assert_called_with('testsource2', unittest.mock.ANY)
+        source_target._write.assert_called_with("testsource2", unittest.mock.ANY)
 
         # Change from SHC
-        await self.interface_runner.run_coro_async(default_sink_connector.write('testsink1', [self]))
+        await self.interface_runner.run_coro_async(default_sink_connector.write("testsink1", [self]))
         await asyncio.sleep(0.1)
-        sink_target._write.assert_called_with('testsink1', [self, default_sink_connector])
-        await asyncio.wrap_future(asyncio.run_coroutine_threadsafe(
-            default_source_connector.write('testsource1', [self]),
-            loop=self.interface_runner.loop))
+        sink_target._write.assert_called_with("testsink1", [self, default_sink_connector])
+        await asyncio.wrap_future(
+            asyncio.run_coroutine_threadsafe(
+                default_source_connector.write("testsource1", [self]), loop=self.interface_runner.loop
+            )
+        )
         await asyncio.sleep(0.1)
-        source_target._write.assert_called_with('testsource1', [self, default_source_connector])
+        source_target._write.assert_called_with("testsource1", [self, default_source_connector])
 
     def test_repr(self) -> None:
         self.assertRegex(repr(self.interface), r"PulseAudioInterface\(pulse_server_socket='unix:/.*?/pulse/native'\)")
 
     async def _run_pactl(self, *args) -> str:
         proc = await asyncio.create_subprocess_exec(
-            'pactl',
-            '-s',
+            "pactl",
+            "-s",
             self.pulse_url,
             *args,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
-            env=dict(LC_MESSAGES='C', PATH=os.environ['PATH'])
+            env=dict(LC_MESSAGES="C", PATH=os.environ["PATH"]),
         )
         stdout, stderr = await proc.communicate()
         if proc.returncode:
@@ -449,27 +455,29 @@ class SinkConnectorTests(unittest.TestCase):
         :return: A dict of all the properties of the Pulseaudio object of interest, e.g.
             {'Name': …, 'Volume': …, 'Mute': …, …}
         """
-        data = await self._run_pactl('list', facility + 's')
-        items = re.split(r'(?:\n|^)[\w ]+ #\d+\n', data)
+        data = await self._run_pactl("list", facility + "s")
+        items = re.split(r"(?:\n|^)[\w ]+ #\d+\n", data)
         for text in items[1:]:
             name_match = re.search(r"(?:\n|^)\s*Name: (.*?)\n", text)
             if not name_match or name_match.group(1).strip() != name:
                 continue
-            entries = re.split(r'(?:\n|^)\t([\w ]+): ', text)
+            entries = re.split(r"(?:\n|^)\t([\w ]+): ", text)
             a = iter(entries[1:])
             return {k: v.strip() for k, v in zip(a, a)}
         raise KeyError(f"No {facility} with name '{name}' found in pactl output.")
 
 
 def create_dummy_instance() -> Tuple[Path, subprocess.Popen]:
-    pulse_dir = tempfile.mkdtemp(prefix='shc-pulse-tests.')
-    env = dict(PATH=os.environ['PATH'], XDG_RUNTIME_DIR=pulse_dir, PULSE_STATE_PATH=pulse_dir)
+    pulse_dir = tempfile.mkdtemp(prefix="shc-pulse-tests.")
+    env = dict(PATH=os.environ["PATH"], XDG_RUNTIME_DIR=pulse_dir, PULSE_STATE_PATH=pulse_dir)
     proc = subprocess.Popen(
-        ['pulseaudio', '--daemonize=no', '--fail',
-         '-nF', '/dev/stdin', '--exit-idle-time=-1', '--log-level=error'],
-        env=env, stdin=subprocess.PIPE)
+        ["pulseaudio", "--daemonize=no", "--fail", "-nF", "/dev/stdin", "--exit-idle-time=-1", "--log-level=error"],
+        env=env,
+        stdin=subprocess.PIPE,
+    )
     assert proc.stdin is not None
-    proc.stdin.write("""
+    proc.stdin.write(
+        """
 load-module module-suspend-on-idle
 load-module module-filter-heuristics
 load-module module-filter-apply
@@ -479,6 +487,7 @@ load-module module-null-sink sink_name=testsink1
 load-module module-null-sink sink_name=testsink2 channels=6 channel_map=front-left,front-right,rear-left,rear-right,front-center,lfe
 load-module module-null-source source_name=testsource1
 load-module module-null-source source_name=testsource2
-""".encode())  # noqa: E501
+""".encode()
+    )  # noqa: E501
     proc.stdin.close()
     return Path(pulse_dir), proc

--- a/test/interfaces/test_shc_client.py
+++ b/test/interfaces/test_shc_client.py
@@ -19,8 +19,14 @@ import aiohttp
 
 import shc.web
 import shc.interfaces.shc_client
-from test._helper import ExampleReadable, InterfaceThreadRunner, ExampleWritable, ExampleSubscribable, async_test, \
-    AsyncMock
+from test._helper import (
+    ExampleReadable,
+    InterfaceThreadRunner,
+    ExampleWritable,
+    ExampleSubscribable,
+    async_test,
+    AsyncMock,
+)
 
 
 class ExampleType(NamedTuple):
@@ -31,7 +37,7 @@ class ExampleType(NamedTuple):
 class SHCWebsocketClientTest(unittest.TestCase):
     def setUp(self) -> None:
         self.server_runner = InterfaceThreadRunner(shc.web.WebServer, "localhost", 42080)
-        self.client_runner = InterfaceThreadRunner(shc.interfaces.shc_client.SHCWebClient, 'http://localhost:42080')
+        self.client_runner = InterfaceThreadRunner(shc.interfaces.shc_client.SHCWebClient, "http://localhost:42080")
         self.server = self.server_runner.interface
         self.client = self.client_runner.interface
 
@@ -41,12 +47,11 @@ class SHCWebsocketClientTest(unittest.TestCase):
 
     def test_subscribe(self) -> None:
         self.server.api(int, "foo")
-        bar_object = self.server.api(ExampleType, "bar")\
-            .connect(ExampleReadable(ExampleType, ExampleType(42, True)))
+        bar_object = self.server.api(ExampleType, "bar").connect(ExampleReadable(ExampleType, ExampleType(42, True)))
         bar_source = ExampleSubscribable(ExampleType).connect(bar_object)
 
-        client_foo = self.client.object(int, 'foo')
-        client_bar = self.client.object(ExampleType, 'bar')
+        client_foo = self.client.object(int, "foo")
+        client_bar = self.client.object(ExampleType, "bar")
         foo_target = ExampleWritable(int).connect(client_foo)
         bar_target = ExampleWritable(ExampleType).connect(client_bar)
 
@@ -68,12 +73,12 @@ class SHCWebsocketClientTest(unittest.TestCase):
         self.server.api(int, "foo")
         self.server.api(ExampleType, "bar")
 
-        bar_client = self.client.object(int, 'bar')
+        bar_client = self.client.object(int, "bar")
 
         # Creating an option with equal name should return the same object again or raise a type error
-        self.assertIs(self.client.object(int, 'bar'), bar_client)
+        self.assertIs(self.client.object(int, "bar"), bar_client)
         with self.assertRaises(TypeError):
-            self.client.object(str, 'bar')
+            self.client.object(str, "bar")
 
         # Test raising of connection errors on startup (server is not started yet)
         with self.assertRaises(aiohttp.ClientConnectionError):
@@ -83,8 +88,8 @@ class SHCWebsocketClientTest(unittest.TestCase):
 
         # Test raising of subscription errors on startup (inexistent api object name)
         # This requires that the object has a local subscriber (otherwise, subscription is skipped)
-        another_client = shc.interfaces.shc_client.SHCWebClient('http://localhost:42080')
-        foobar = another_client.object(int, 'foobar')
+        another_client = shc.interfaces.shc_client.SHCWebClient("http://localhost:42080")
+        foobar = another_client.object(int, "foobar")
         foobar.subscribe(ExampleWritable(int))
         try:
             with self.assertRaises(shc.interfaces.shc_client.WebSocketAPIError):
@@ -94,11 +99,10 @@ class SHCWebsocketClientTest(unittest.TestCase):
 
     def test_read(self) -> None:
         self.server.api(int, "foo")
-        self.server.api(ExampleType, "bar")\
-            .connect(ExampleReadable(ExampleType, ExampleType(42, True)))
+        self.server.api(ExampleType, "bar").connect(ExampleReadable(ExampleType, ExampleType(42, True)))
 
-        client_foo = self.client.object(int, 'foo')
-        client_bar = self.client.object(ExampleType, 'bar')
+        client_foo = self.client.object(int, "foo")
+        client_bar = self.client.object(ExampleType, "bar")
 
         self.server_runner.start()
         self.client_runner.start()
@@ -114,7 +118,7 @@ class SHCWebsocketClientTest(unittest.TestCase):
         server_bar = self.server.api(ExampleType, "bar")
         target = ExampleWritable(ExampleType).connect(server_bar)
 
-        client_bar = self.client.object(ExampleType, 'bar')
+        client_bar = self.client.object(ExampleType, "bar")
 
         self.server_runner.start()
         self.client_runner.start()
@@ -142,7 +146,7 @@ class SHCWebsocketClientTest(unittest.TestCase):
         target._write.assert_called_with(False, unittest.mock.ANY)
 
         # Test raising of an error on startup if the object does not exist at the server
-        another_client = shc.interfaces.shc_client.SHCWebClient('http://localhost:42080', client_online_object="foobar")
+        another_client = shc.interfaces.shc_client.SHCWebClient("http://localhost:42080", client_online_object="foobar")
         try:
             with self.assertRaises(shc.interfaces.shc_client.WebSocketAPIError):
                 asyncio.get_event_loop().run_until_complete(another_client.start())
@@ -150,17 +154,15 @@ class SHCWebsocketClientTest(unittest.TestCase):
             asyncio.get_event_loop().run_until_complete(another_client.stop())
 
     def test_reconnect(self) -> None:
-        self.server.api(ExampleType, "bar")\
-            .connect(ExampleReadable(ExampleType, ExampleType(42, True)))
+        self.server.api(ExampleType, "bar").connect(ExampleReadable(ExampleType, ExampleType(42, True)))
         foo_server_target = ExampleWritable(int).connect(self.server.api(int, "foo"))
 
-        client_bar = self.client.object(ExampleType, 'bar')
-        bar_target = ExampleWritable(ExampleType)\
-            .connect(client_bar)
-        _client_foo = self.client.object(int, 'foo')\
-            .connect(ExampleReadable(int, 56), read=True)  # noqa: F841
-        client_status_target = ExampleWritable(shc.supervisor.InterfaceStatus)\
-            .connect(self.client.monitoring_connector())
+        client_bar = self.client.object(ExampleType, "bar")
+        bar_target = ExampleWritable(ExampleType).connect(client_bar)
+        _client_foo = self.client.object(int, "foo").connect(ExampleReadable(int, 56), read=True)  # noqa: F841
+        client_status_target = ExampleWritable(shc.supervisor.InterfaceStatus).connect(
+            self.client.monitoring_connector()
+        )
 
         self.server_runner.start()
         self.client_runner.start()
@@ -168,8 +170,10 @@ class SHCWebsocketClientTest(unittest.TestCase):
         bar_target._write.assert_called_once_with(ExampleType(42, True), [client_bar])
         bar_target._write.reset_mock()
         foo_server_target._write.assert_called_once_with(56, unittest.mock.ANY)
-        self.assertEqual(shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""),
-                         self.client_runner.run_coro(self.client.monitoring_connector().read()))
+        self.assertEqual(
+            shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""),
+            self.client_runner.run_coro(self.client.monitoring_connector().read()),
+        )
         client_status_target._write.reset_mock()
         # We cannot use ClockMock here, since it does not support asyncio.wait()
 
@@ -178,17 +182,16 @@ class SHCWebsocketClientTest(unittest.TestCase):
         self.assertIn("Unexpected shutdown", ctx.output[0])
         self.assertIn("SHCWebClient", ctx.output[0])
 
-        expected_status = shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.CRITICAL,
-                                                         "Unexpected shutdown of interface")
-        self.assertEqual(expected_status,
-                         self.client_runner.run_coro(self.client.monitoring_connector().read()))
+        expected_status = shc.supervisor.InterfaceStatus(
+            shc.supervisor.ServiceStatus.CRITICAL, "Unexpected shutdown of interface"
+        )
+        self.assertEqual(expected_status, self.client_runner.run_coro(self.client.monitoring_connector().read()))
         client_status_target._write.assert_called_with(expected_status, unittest.mock.ANY)
 
         # Re-setup server
         self.server_runner = InterfaceThreadRunner(shc.web.WebServer, "localhost", 42080)
         self.server = self.server_runner.interface
-        self.server.api(ExampleType, "bar")\
-            .connect(ExampleReadable(ExampleType, ExampleType(42, True)))
+        self.server.api(ExampleType, "bar").connect(ExampleReadable(ExampleType, ExampleType(42, True)))
         foo_server_target = ExampleWritable(int).connect(self.server.api(int, "foo"))
 
         # Wait for first reconnect attempt
@@ -201,7 +204,7 @@ class SHCWebsocketClientTest(unittest.TestCase):
         self.server_runner.start()
 
         # Wait for second reconnect attempt
-        with unittest.mock.patch.object(self.client._session, 'ws_connect', new=AsyncMock()) as connect_mock:
+        with unittest.mock.patch.object(self.client._session, "ws_connect", new=AsyncMock()) as connect_mock:
             time.sleep(1)
             connect_mock.assert_not_called()
         time.sleep(0.3)
@@ -209,14 +212,17 @@ class SHCWebsocketClientTest(unittest.TestCase):
         bar_target._write.assert_called_once_with(ExampleType(42, True), [client_bar])
         foo_server_target._write.assert_called_once_with(56, unittest.mock.ANY)
 
-        self.assertEqual(shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""),
-                         self.client_runner.run_coro(self.client.monitoring_connector().read()))
+        self.assertEqual(
+            shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""),
+            self.client_runner.run_coro(self.client.monitoring_connector().read()),
+        )
         client_status_target._write.assert_called_with(
-            shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""), unittest.mock.ANY)
+            shc.supervisor.InterfaceStatus(shc.supervisor.ServiceStatus.OK, ""), unittest.mock.ANY
+        )
 
     def test_initial_reconnect(self) -> None:
         self.client.failsafe_start = True
-        client_bar = self.client.object(ExampleType, 'bar')
+        client_bar = self.client.object(ExampleType, "bar")
         bar_target = ExampleWritable(ExampleType).connect(client_bar)
 
         # We cannot use ClockMock here, since the server seems to be too slow then
@@ -240,12 +246,11 @@ class SHCWebsocketClientTest(unittest.TestCase):
         self.server_runner.stop()
         self.server_runner = InterfaceThreadRunner(shc.web.WebServer, "localhost", 42080)
         self.server = self.server_runner.interface
-        self.server.api(ExampleType, "bar") \
-            .connect(ExampleReadable(ExampleType, ExampleType(42, True)))
+        self.server.api(ExampleType, "bar").connect(ExampleReadable(ExampleType, ExampleType(42, True)))
         self.server_runner.start()
 
         # wait for second reconnect attempt
-        with unittest.mock.patch.object(self.client._session, 'ws_connect', new=AsyncMock()) as connect_mock:
+        with unittest.mock.patch.object(self.client._session, "ws_connect", new=AsyncMock()) as connect_mock:
             time.sleep(1)
             connect_mock.assert_not_called()
         time.sleep(0.3)
@@ -256,7 +261,7 @@ class SHCWebsocketClientTest(unittest.TestCase):
 class SHCWebsocketClientConcurrentUpdateTest(unittest.TestCase):
     def setUp(self) -> None:
         self.server = shc.web.WebServer("localhost", 42080)
-        self.client = shc.interfaces.shc_client.SHCWebClient('http://localhost:42080')
+        self.client = shc.interfaces.shc_client.SHCWebClient("http://localhost:42080")
 
     def tearDown(self) -> None:
         loop = asyncio.get_event_loop()
@@ -265,9 +270,9 @@ class SHCWebsocketClientConcurrentUpdateTest(unittest.TestCase):
 
     @async_test
     async def test_concurrent_update(self) -> None:
-        foo_api = self.server.api(int, 'foo')
+        foo_api = self.server.api(int, "foo")
         server_var = shc.Variable(int, initial_value=0).connect(foo_api)
-        foo_client = self.client.object(int, 'foo')
+        foo_client = self.client.object(int, "foo")
         client_var = shc.Variable(int).connect(foo_client)
 
         await self.server.start()
@@ -276,8 +281,6 @@ class SHCWebsocketClientConcurrentUpdateTest(unittest.TestCase):
 
         self.assertEqual(0, await client_var.read())
 
-        await asyncio.gather(foo_api.write(42, [self]),
-                             foo_client.write(56, [self]))
+        await asyncio.gather(foo_api.write(42, [self]), foo_client.write(56, [self]))
         await asyncio.sleep(0.1)
-        self.assertEqual(await client_var.read(),
-                         await server_var.read())
+        self.assertEqual(await client_var.read(), await server_var.read())

--- a/test/interfaces/test_tasmota.py
+++ b/test/interfaces/test_tasmota.py
@@ -29,10 +29,11 @@ class TasmotaInterfaceTest(unittest.TestCase):
 
         self.client_runner = InterfaceThreadRunner(shc.interfaces.mqtt.MQTTClientInterface, "localhost", 42883)
         self.client = self.client_runner.interface
-        self.interface: shc.interfaces.tasmota.TasmotaInterface = \
-            self.client_runner.run_coro(_construct(self.client, 'test-device'))
-        broker_config_file = Path(__file__).parent.parent / 'assets' / 'mosquitto.conf'
-        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", '-c', str(broker_config_file)])
+        self.interface: shc.interfaces.tasmota.TasmotaInterface = self.client_runner.run_coro(
+            _construct(self.client, "test-device")
+        )
+        broker_config_file = Path(__file__).parent.parent / "assets" / "mosquitto.conf"
+        self.broker_process = subprocess.Popen(["mosquitto", "-p", "42883", "-c", str(broker_config_file)])
         time.sleep(0.25)
 
     def tearDown(self) -> None:
@@ -53,7 +54,8 @@ class TasmotaInterfaceTest(unittest.TestCase):
         self.assertEqual(False, self.client_runner.run_coro(offline_connector.read()))
         self.assertEqual(
             InterfaceStatus(ServiceStatus.CRITICAL, "No Last Will or telemetry received from Tasmota device by now"),
-            self.client_runner.run_coro(status_connector.read()))
+            self.client_runner.run_coro(status_connector.read()),
+        )
 
         task = asyncio.create_task(tasmota_device_mock("test-device"))
         await asyncio.sleep(0.1)
@@ -62,8 +64,9 @@ class TasmotaInterfaceTest(unittest.TestCase):
             target_offline._write.assert_called_once_with(True, unittest.mock.ANY)
             target_status._write.assert_called_with(InterfaceStatus(ServiceStatus.OK, ""), unittest.mock.ANY)
             self.assertEqual(True, self.client_runner.run_coro(offline_connector.read()))
-            self.assertEqual(InterfaceStatus(ServiceStatus.OK, ""),
-                             self.client_runner.run_coro(status_connector.read()))
+            self.assertEqual(
+                InterfaceStatus(ServiceStatus.OK, ""), self.client_runner.run_coro(status_connector.read())
+            )
 
             task.cancel()
             with suppress(asyncio.CancelledError):
@@ -72,8 +75,8 @@ class TasmotaInterfaceTest(unittest.TestCase):
             await asyncio.sleep(0.1)
             target_offline._write.assert_called_with(False, unittest.mock.ANY)
             target_status._write.assert_called_with(
-                InterfaceStatus(ServiceStatus.CRITICAL, "Tasmota device is offline"),
-                unittest.mock.ANY)
+                InterfaceStatus(ServiceStatus.CRITICAL, "Tasmota device is offline"), unittest.mock.ANY
+            )
 
         except Exception:
             task.cancel()
@@ -110,7 +113,7 @@ class TasmotaInterfaceTest(unittest.TestCase):
     async def test_telemetry_warning_state(self) -> None:
         # Recreate Tasmota interface with really short telemetry timeout
         async def _construct(*args):
-            return shc.interfaces.tasmota.TasmotaInterface(self.client, 'test-device', telemetry_interval=0.03)
+            return shc.interfaces.tasmota.TasmotaInterface(self.client, "test-device", telemetry_interval=0.03)
 
         self.interface = self.client_runner.run_coro(_construct())
 
@@ -127,12 +130,14 @@ class TasmotaInterfaceTest(unittest.TestCase):
             target_status._write.assert_called_with(InterfaceStatus(ServiceStatus.OK, ""), unittest.mock.ANY)
 
             await asyncio.sleep(0.02)  # more than 1,5x 0,01s; so we should get a warning
-            target_status._write.assert_called_with(InterfaceStatus(ServiceStatus.WARNING, unittest.mock.ANY),
-                                                    unittest.mock.ANY)
+            target_status._write.assert_called_with(
+                InterfaceStatus(ServiceStatus.WARNING, unittest.mock.ANY), unittest.mock.ANY
+            )
 
             await asyncio.sleep(0.3)  # more than 10x 0,01s; so we should get an error
-            target_status._write.assert_called_with(InterfaceStatus(ServiceStatus.CRITICAL, unittest.mock.ANY),
-                                                    unittest.mock.ANY)
+            target_status._write.assert_called_with(
+                InterfaceStatus(ServiceStatus.CRITICAL, unittest.mock.ANY), unittest.mock.ANY
+            )
 
         finally:
             task.cancel()
@@ -160,7 +165,7 @@ class TasmotaInterfaceTest(unittest.TestCase):
             target_power._write.assert_called_once_with(False, unittest.mock.ANY)
 
             async with aiomqtt.Client("localhost", 42883, identifier="some-other-client") as c:
-                await c.publish("cmnd/test-device/color", b'#aabbcc', retain=True)
+                await c.publish("cmnd/test-device/color", b"#aabbcc", retain=True)
 
             await asyncio.sleep(0.1)
             target_color._write.assert_called_with(construct_color(170, 187, 204, 0), [conn_color])  # rounding error
@@ -194,8 +199,11 @@ class TasmotaInterfaceTest(unittest.TestCase):
             target_color._write.assert_called_once_with(construct_color(0, 0, 0, 0), unittest.mock.ANY)
             target_power._write.assert_called_once_with(False, unittest.mock.ANY)
 
-            future = asyncio.wrap_future(asyncio.run_coroutine_threadsafe(
-                conn_color.write(construct_color(175, 117, 48, 66), [self]), loop=self.client_runner.loop))
+            future = asyncio.wrap_future(
+                asyncio.run_coroutine_threadsafe(
+                    conn_color.write(construct_color(175, 117, 48, 66), [self]), loop=self.client_runner.loop
+                )
+            )
             # Should only return when the message returns from the broker
             await asyncio.sleep(0.0005)
             self.assertFalse(future.done())
@@ -222,13 +230,15 @@ class TasmotaInterfaceTest(unittest.TestCase):
         target_ir._write.assert_not_called()
 
         async with aiomqtt.Client("localhost", 42883, identifier="some-other-client") as c:
-            await c.publish("tele/test-device/RESULT",
-                            json.dumps({"Time": "1970-01-10T03:12:43",
-                                        "IrReceived": {"Protocol": "NEC", "Bits": 32, "Data": "0x00F7609F"}})
-                            .encode('ascii'))
+            await c.publish(
+                "tele/test-device/RESULT",
+                json.dumps(
+                    {"Time": "1970-01-10T03:12:43", "IrReceived": {"Protocol": "NEC", "Bits": 32, "Data": "0x00F7609F"}}
+                ).encode("ascii"),
+            )
 
         await asyncio.sleep(0.25)
-        target_ir._write.assert_called_once_with(b'\x00\xF7\x60\x9F', [conn_ir])
+        target_ir._write.assert_called_once_with(b"\x00\xf7\x60\x9f", [conn_ir])
 
     @async_test
     async def test_sensor_power(self) -> None:
@@ -242,13 +252,27 @@ class TasmotaInterfaceTest(unittest.TestCase):
         target_energy._write.assert_not_called()
 
         async with aiomqtt.Client("localhost", 42883, identifier="some-other-client") as c:
-            await c.publish("tele/test-device/SENSOR",
-                            json.dumps({"Time": "1970-01-01T00:49:50",
-                                        "ENERGY": {"TotalStartTime": "1970-01-01T00:00:00", "Total": 0.012,
-                                                   "Yesterday": 0.000, "Today": 0.012, "Period": 2, "Power": 15,
-                                                   "ApparentPower": 26, "ReactivePower": 22, "Factor": 0.56,
-                                                   "Voltage": 227, "Current": 0.114}})
-                            .encode('ascii'))
+            await c.publish(
+                "tele/test-device/SENSOR",
+                json.dumps(
+                    {
+                        "Time": "1970-01-01T00:49:50",
+                        "ENERGY": {
+                            "TotalStartTime": "1970-01-01T00:00:00",
+                            "Total": 0.012,
+                            "Yesterday": 0.000,
+                            "Today": 0.012,
+                            "Period": 2,
+                            "Power": 15,
+                            "ApparentPower": 26,
+                            "ReactivePower": 22,
+                            "Factor": 0.56,
+                            "Voltage": 227,
+                            "Current": 0.114,
+                        },
+                    }
+                ).encode("ascii"),
+            )
 
         await asyncio.sleep(0.25)
         expected = shc.interfaces.tasmota.TasmotaEnergyMeasurement(
@@ -259,9 +283,10 @@ class TasmotaInterfaceTest(unittest.TestCase):
             apparent_power=26.0,
             reactive_power=22.0,
             total_energy=0.012,
-            frequency=float('NaN'),
+            frequency=float("NaN"),
             total_energy_today=0.012,
-            total_energy_yesterday=0.0)
+            total_energy_yesterday=0.0,
+        )
         target_energy._write.assert_called_once_with(unittest.mock.ANY, [conn_energy])
         self.assertIsInstance(target_energy._write.call_args[0][0], shc.interfaces.tasmota.TasmotaEnergyMeasurement)
         for a, (name, e) in zip(target_energy._write.call_args[0][0], expected._asdict().items()):
@@ -271,14 +296,37 @@ class TasmotaInterfaceTest(unittest.TestCase):
 
 
 BASE_STATUS11: Dict[str, Dict[str, Any]] = {
-    "StatusSTS":
-        {"Time": "1970-01-08T04:46:42", "Uptime": "7T04:46:38", "UptimeSec": 621998, "Heap": 26,
-         "SleepMode": "Dynamic", "Sleep": 50, "LoadAvg": 19, "MqttCount": 1, "POWER": "OFF", "Dimmer": 100,
-         "Color": "00CCFFEE", "HSBColor": "192,100,100", "White": 93, "Channel": [0, 80, 100, 93],
-         "Scheme": 0, "Fade": "OFF", "Speed": 1, "LedTable": "ON",
-         "Wifi": {
-             "AP": 1, "SSId": "some-network", "BSSId": "00:11:22:33:44:55", "Channel": 11, "RSSI": 76,
-             "Signal": -62, "LinkCount": 1, "Downtime": "0T00:00:03"}}}
+    "StatusSTS": {
+        "Time": "1970-01-08T04:46:42",
+        "Uptime": "7T04:46:38",
+        "UptimeSec": 621998,
+        "Heap": 26,
+        "SleepMode": "Dynamic",
+        "Sleep": 50,
+        "LoadAvg": 19,
+        "MqttCount": 1,
+        "POWER": "OFF",
+        "Dimmer": 100,
+        "Color": "00CCFFEE",
+        "HSBColor": "192,100,100",
+        "White": 93,
+        "Channel": [0, 80, 100, 93],
+        "Scheme": 0,
+        "Fade": "OFF",
+        "Speed": 1,
+        "LedTable": "ON",
+        "Wifi": {
+            "AP": 1,
+            "SSId": "some-network",
+            "BSSId": "00:11:22:33:44:55",
+            "Channel": 11,
+            "RSSI": 76,
+            "Signal": -62,
+            "LinkCount": 1,
+            "Downtime": "0T00:00:03",
+        },
+    }
+}
 
 
 async def tasmota_device_mock(deviceid: str) -> None:
@@ -287,51 +335,55 @@ async def tasmota_device_mock(deviceid: str) -> None:
     power = False
 
     async with aiomqtt.Client("localhost", 42883, identifier="FakeTasmotaDevice") as c:
-        await c.subscribe(f'cmnd/{deviceid}/+')
-        await c.publish(f"tele/{deviceid}/LWT", b'Online', retain=True)
+        await c.subscribe(f"cmnd/{deviceid}/+")
+        await c.publish(f"tele/{deviceid}/LWT", b"Online", retain=True)
 
         try:
             async for msg in c.messages:
                 topic = str(msg.topic)
                 payload = typing.cast(bytes, msg.payload)  # payload of received MQTT messages is always bytes
-                if topic == f'cmnd/{deviceid}/status':
-                    if payload.strip() == b'11':
+                if topic == f"cmnd/{deviceid}/status":
+                    if payload.strip() == b"11":
                         status = BASE_STATUS11.copy()
-                        status['StatusSTS']['POWER'] = 'ON' if power else 'OFF'
-                        status['StatusSTS']['Dimmer'] = int(max(channel)/255*100)
-                        status['StatusSTS']['Channel'] = [int(v/255*100) for v in channel]
-                        status['StatusSTS']['Color'] = \
-                            '{:0>2X}{:0>2X}{:0>2X}{:0>2X}'.format(*channel)
-                        status['StatusSTS']['White'] = int(channel[3]/255*100)
+                        status["StatusSTS"]["POWER"] = "ON" if power else "OFF"
+                        status["StatusSTS"]["Dimmer"] = int(max(channel) / 255 * 100)
+                        status["StatusSTS"]["Channel"] = [int(v / 255 * 100) for v in channel]
+                        status["StatusSTS"]["Color"] = "{:0>2X}{:0>2X}{:0>2X}{:0>2X}".format(*channel)
+                        status["StatusSTS"]["White"] = int(channel[3] / 255 * 100)
                         # TODO insert current HSBColor
-                        await c.publish(f"stat/{deviceid}/STATUS11", json.dumps(status).encode('ascii'))
+                        await c.publish(f"stat/{deviceid}/STATUS11", json.dumps(status).encode("ascii"))
                     else:
                         pass
                         # not implemented
 
-                elif topic == f'cmnd/{deviceid}/power':
-                    power = payload.lower() not in (b'0', 'off', 'false')
-                    await c.publish(f'stat/{deviceid}/RESULT', b'{"POWER":"' + (b'ON' if power else b'OFF') + b'"}')
-                    await c.publish(f'stat/{deviceid}/POWER', b'ON' if power else b'OFF')
+                elif topic == f"cmnd/{deviceid}/power":
+                    power = payload.lower() not in (b"0", "off", "false")
+                    await c.publish(f"stat/{deviceid}/RESULT", b'{"POWER":"' + (b"ON" if power else b"OFF") + b'"}')
+                    await c.publish(f"stat/{deviceid}/POWER", b"ON" if power else b"OFF")
 
-                elif topic == f'cmnd/{deviceid}/color':
-                    if payload[0] == ord('#'):
-                        data = bytes.fromhex(payload.decode('ascii')[1:])
+                elif topic == f"cmnd/{deviceid}/color":
+                    if payload[0] == ord("#"):
+                        data = bytes.fromhex(payload.decode("ascii")[1:])
                         data += bytes([0] * (4 - len(data)))
                         channel = list(data[0:4])
                     else:
                         # not implemented
                         continue
                     power = max(channel) != 0
-                    await c.publish(f'stat/{deviceid}/RESULT',
-                                    json.dumps({"POWER": 'ON' if power else 'OFF',
-                                                "Dimmer": int(max(channel)/255*100),
-                                                "Color": '{:0>2X}{:0>2X}{:0>2X}{:0>2X}'
-                                                         .format(*channel),
-                                                "HSBColor": "48,100,100",  # TODO
-                                                "White": int(channel[3]/255*100),
-                                                "Channel": [int(v/255*100) for v in channel]}).encode('ascii'))
+                    await c.publish(
+                        f"stat/{deviceid}/RESULT",
+                        json.dumps(
+                            {
+                                "POWER": "ON" if power else "OFF",
+                                "Dimmer": int(max(channel) / 255 * 100),
+                                "Color": "{:0>2X}{:0>2X}{:0>2X}{:0>2X}".format(*channel),
+                                "HSBColor": "48,100,100",  # TODO
+                                "White": int(channel[3] / 255 * 100),
+                                "Channel": [int(v / 255 * 100) for v in channel],
+                            }
+                        ).encode("ascii"),
+                    )
 
         except asyncio.CancelledError:
-            await c.publish(f"tele/{deviceid}/LWT", b'Offline', retain=True)
+            await c.publish(f"tele/{deviceid}/LWT", b"Offline", retain=True)
             raise

--- a/test/interfaces/test_telegram.py
+++ b/test/interfaces/test_telegram.py
@@ -21,12 +21,16 @@ logger = logging.getLogger(__name__)
 
 class TelegramBotTest(unittest.TestCase):
     def setUp(self) -> None:
-        self.api_mock = TelegramAPIMock(port=42180,
-                                        user_object={'id': 12345689, 'is_bot': True, 'first_name': "The Bot"})
-        self.auth_provider = shc.interfaces.telegram.SimpleTelegramAuth({'max': 987654123, 'tim': 987654789})
-        self.client_runner = InterfaceThreadRunner(shc.interfaces.telegram.TelegramBot, "123456789:exampleTokenXXX",
-                                                   self.auth_provider,
-                                                   TelegramAPIServer("http://localhost:42180/{token}/{method}", ""))
+        self.api_mock = TelegramAPIMock(
+            port=42180, user_object={"id": 12345689, "is_bot": True, "first_name": "The Bot"}
+        )
+        self.auth_provider = shc.interfaces.telegram.SimpleTelegramAuth({"max": 987654123, "tim": 987654789})
+        self.client_runner = InterfaceThreadRunner(
+            shc.interfaces.telegram.TelegramBot,
+            "123456789:exampleTokenXXX",
+            self.auth_provider,
+            TelegramAPIServer("http://localhost:42180/{token}/{method}", ""),
+        )
         self.client: shc.interfaces.telegram.TelegramBot = self.client_runner.interface
 
     def tearDown(self) -> None:
@@ -35,8 +39,7 @@ class TelegramBotTest(unittest.TestCase):
 
     @async_test
     async def test_subscribe(self) -> None:
-        foo_source = ExampleSubscribable(bool)\
-            .connect(self.client.on_off_connector("Foo", set(), send_users={'max'}))
+        foo_source = ExampleSubscribable(bool).connect(self.client.on_off_connector("Foo", set(), send_users={"max"}))
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -54,32 +57,42 @@ class TelegramBotTest(unittest.TestCase):
         await asyncio.sleep(0.05)
         self.api_mock.reset_mock()
 
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
-                                                      'text': "/start"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
+                    "text": "/start",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", text="Hi!\nI'm an SHC bot!", chat_id="987654123")
 
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654125, 'is_bot': False, 'first_name': "Eve"},
-                                                      'chat': {'id': 987654125, 'type': 'private', 'first_name': "Eve"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
-                                                      'text': "/start"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654125, "is_bot": False, "first_name": "Eve"},
+                    "chat": {"id": 987654125, "type": "private", "first_name": "Eve"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
+                    "text": "/start",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_call_count(3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654125")
-        self.assertIn("Unauthorized", self.api_mock.method_calls[-1][1]['text'])
+        self.assertIn("Unauthorized", self.api_mock.method_calls[-1][1]["text"])
 
     @async_test
     async def test_write(self) -> None:
-        foo = self.client.on_off_connector("Foo", {'max', 'tim'})
-        _foo_target = ExampleWritable(bool)\
-            .connect(foo)  # noqa: F841
-        foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'})
-        foobar_target = ExampleWritable(int)\
-            .connect(foobar)
+        foo = self.client.on_off_connector("Foo", {"max", "tim"})
+        _foo_target = ExampleWritable(bool).connect(foo)  # noqa: F841
+        foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {"max", "alice"})
+        foobar_target = ExampleWritable(int).connect(foobar)
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -87,98 +100,146 @@ class TelegramBotTest(unittest.TestCase):
         self.api_mock.reset_mock()
 
         # Search for 'Foo'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertListEqual([[{'text': "/s Foo"}], [{'text': "/s Foobar"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertListEqual(
+            [[{"text": "/s Foo"}], [{"text": "/s Foobar"}]],
+            json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"],
+        )
         self.api_mock.reset_mock()
 
         # Select 'Foobar'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertNotIn("current", self.api_mock.method_calls[-1][1]['text'])
-        reply_markup = json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])
-        self.assertListEqual([[{'text': "cancel", 'callback_data': 'cancel'}]], reply_markup['inline_keyboard'])
+        self.assertNotIn("current", self.api_mock.method_calls[-1][1]["text"])
+        reply_markup = json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])
+        self.assertListEqual([[{"text": "cancel", "callback_data": "cancel"}]], reply_markup["inline_keyboard"])
         self.api_mock.reset_mock()
 
         # Test invalid value
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345791,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 40).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345791,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 40).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn("invalid literal", self.api_mock.method_calls[-1][1]['text'])
+        self.assertIn("invalid literal", self.api_mock.method_calls[-1][1]["text"])
         self.assertNotIn("reply_markup", self.api_mock.method_calls[-1][1])
         self.api_mock.reset_mock()
 
         # Concurrent search by Tim
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345792,
-                                                      'from': {'id': 987654789, 'is_bot': False, 'first_name': "Tim"},
-                                                      'chat': {'id': 987654789, 'type': 'private', 'first_name': "Tim"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 40, 20).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345792,
+                    "from": {"id": 987654789, "is_bot": False, "first_name": "Tim"},
+                    "chat": {"id": 987654789, "type": "private", "first_name": "Tim"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 40, 20).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654789")
-        self.assertListEqual([[{'text': "/s Foo"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertListEqual(
+            [[{"text": "/s Foo"}]], json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"]
+        )
         self.api_mock.reset_mock()
 
         # Max writes value 25
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345793,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 41).timestamp(),
-                                                      'text': "25"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345793,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 41).timestamp(),
+                    "text": "25",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         foobar_target._write.assert_called_once_with(25, [foobar])
         self.api_mock.reset_mock()
 
         # Search again for Foo
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertListEqual([[{'text': "/s Foo"}], [{'text': "/s Foobar"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertListEqual(
+            [[{"text": "/s Foo"}], [{"text": "/s Foobar"}]],
+            json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"],
+        )
         self.api_mock.reset_mock()
 
         # Two authentication error: Tim is not allowed to select Foobar at all
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345792,
-                                                      'from': {'id': 987654789, 'is_bot': False, 'first_name': "Tim"},
-                                                      'chat': {'id': 987654789, 'type': 'private', 'first_name': "Tim"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 44).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345792,
+                    "from": {"id": 987654789, "is_bot": False, "first_name": "Tim"},
+                    "chat": {"id": 987654789, "type": "private", "first_name": "Tim"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 44).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654789")
-        self.assertIn("authorized", self.api_mock.method_calls[-1][1]['text'])
+        self.assertIn("authorized", self.api_mock.method_calls[-1][1]["text"])
         self.api_mock.reset_mock()
 
     @async_test
     async def test_inline_cancel(self) -> None:
-        _foo = self.client.on_off_connector("Foo", {'max', 'tim'})\
-            .connect(ExampleReadable(bool, False))  # noqa: F841
-        _foobar = self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {'max', 'alice'})\
-            .connect(ExampleReadable(int, 42))\
-            .connect(ExampleWritable(int))  # noqa: F841
+        _foo = self.client.on_off_connector("Foo", {"max", "tim"}).connect(ExampleReadable(bool, False))  # noqa: F841
+        _foobar = (
+            self.client.generic_connector(int, "Foobar", lambda x: str(x), lambda x: int(x), {"max", "alice"})
+            .connect(ExampleReadable(int, 42))
+            .connect(ExampleWritable(int))
+        )  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -186,54 +247,72 @@ class TelegramBotTest(unittest.TestCase):
         self.api_mock.reset_mock()
 
         # Select 'Foobar'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654123")
-        reply_markup = json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])
-        self.assertListEqual([[{'text': "cancel", 'callback_data': 'cancel'}]], reply_markup['inline_keyboard'])
+        reply_markup = json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])
+        self.assertListEqual([[{"text": "cancel", "callback_data": "cancel"}]], reply_markup["inline_keyboard"])
         message_data = self.api_mock.method_calls[-1][2]
         self.api_mock.reset_mock()
 
         # Cancel using callback button
-        self.api_mock.add_update_for_bot({'callback_query': {
-            'id': "12345790",
-            'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-            'message': message_data,
-            'chat_instance': "xyz",
-            'data': 'cancel',
-        }})
+        self.api_mock.add_update_for_bot(
+            {
+                "callback_query": {
+                    "id": "12345790",
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "message": message_data,
+                    "chat_instance": "xyz",
+                    "data": "cancel",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         # We expect to API method calls: Removing the inline keyboard and sending a "Action cancelled" message
         self.api_mock.assert_method_call_count(2)
         self.assertEqual("editMessageReplyMarkup", self.api_mock.method_calls[0][0])
-        self.assertEqual(str(message_data['message_id']), self.api_mock.method_calls[0][1]['message_id'])
-        self.assertNotIn('reply_markup', self.api_mock.method_calls[0][1])
+        self.assertEqual(str(message_data["message_id"]), self.api_mock.method_calls[0][1]["message_id"])
+        self.assertNotIn("reply_markup", self.api_mock.method_calls[0][1])
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn("cancelled", self.api_mock.method_calls[1][1]['text'])
+        self.assertIn("cancelled", self.api_mock.method_calls[1][1]["text"])
         self.api_mock.reset_mock()
 
         # Search again for Foo
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertNotIn("invalid", self.api_mock.method_calls[-1][1]['text'])
-        self.assertListEqual([[{'text': "/s Foo"}], [{'text': "/s Foobar"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertNotIn("invalid", self.api_mock.method_calls[-1][1]["text"])
+        self.assertListEqual(
+            [[{"text": "/s Foo"}], [{"text": "/s Foobar"}]],
+            json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"],
+        )
 
     @async_test
     async def test_auth_errors(self) -> None:
-        _foo = self.client.on_off_connector("Foo", {'max', 'tim'})  # noqa: F841
+        _foo = self.client.on_off_connector("Foo", {"max", "tim"})  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -241,46 +320,63 @@ class TelegramBotTest(unittest.TestCase):
         self.api_mock.reset_mock()
 
         # Eve is not allowed to select Foo
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654125, 'is_bot': False, 'first_name': "Eve"},
-                                                      'chat': {'id': 987654125, 'type': 'private', 'first_name': "Eve"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 43).timestamp(),
-                                                      'text': "/s Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654125, "is_bot": False, "first_name": "Eve"},
+                    "chat": {"id": 987654125, "type": "private", "first_name": "Eve"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 43).timestamp(),
+                    "text": "/s Foo",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654125")
-        foo_error_message = self.api_mock.method_calls[-1][1]['text']
+        foo_error_message = self.api_mock.method_calls[-1][1]["text"]
         self.assertIn("authorized", foo_error_message)
         self.api_mock.reset_mock()
 
         # Eve is not allowed to select a non-existent object.
         # The message should be the same as for the existant object, so we don't leak information about existant objects
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345791,
-                                                      'from': {'id': 987654125, 'is_bot': False, 'first_name': "Eve"},
-                                                      'chat': {'id': 987654125, 'type': 'private', 'first_name': "Eve"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 43, 1).timestamp(),
-                                                      'text': "/s Bar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345791,
+                    "from": {"id": 987654125, "is_bot": False, "first_name": "Eve"},
+                    "chat": {"id": 987654125, "type": "private", "first_name": "Eve"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 43, 1).timestamp(),
+                    "text": "/s Bar",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654125")
-        self.assertEqual(foo_error_message, self.api_mock.method_calls[-1][1]['text'])
+        self.assertEqual(foo_error_message, self.api_mock.method_calls[-1][1]["text"])
         self.api_mock.reset_mock()
 
         # Eve is not allowed to search anything
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345791,
-                                                      'from': {'id': 987654125, 'is_bot': False, 'first_name': "Eve"},
-                                                      'chat': {'id': 987654125, 'type': 'private', 'first_name': "Eve"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 43, 1).timestamp(),
-                                                      'text': "Fo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345791,
+                    "from": {"id": 987654125, "is_bot": False, "first_name": "Eve"},
+                    "chat": {"id": 987654125, "type": "private", "first_name": "Eve"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 43, 1).timestamp(),
+                    "text": "Fo",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654125")
-        self.assertIn("authorized", self.api_mock.method_calls[-1][1]['text'])
-        self.assertNotIn("Foo", self.api_mock.method_calls[-1][1]['text'])
+        self.assertIn("authorized", self.api_mock.method_calls[-1][1]["text"])
+        self.assertNotIn("Foo", self.api_mock.method_calls[-1][1]["text"])
         self.api_mock.reset_mock()
 
     @async_test
     async def test_write_on_off(self) -> None:
-        foo = self.client.on_off_connector("Foo", {'max', 'tim'})
-        foo_target = ExampleWritable(bool)\
-            .connect(foo)
+        foo = self.client.on_off_connector("Foo", {"max", "tim"})
+        foo_target = ExampleWritable(bool).connect(foo)
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -288,53 +384,81 @@ class TelegramBotTest(unittest.TestCase):
         self.api_mock.reset_mock()
 
         # Select 'Foo'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
-                                                      'text': "/s Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
+                    "text": "/s Foo",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        reply_markup = json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])
-        self.assertListEqual([[{'text': "off"}, {'text': "on"}], [{'text': "/cancel"}]], reply_markup['keyboard'])
+        reply_markup = json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])
+        self.assertListEqual([[{"text": "off"}, {"text": "on"}], [{"text": "/cancel"}]], reply_markup["keyboard"])
         self.api_mock.reset_mock()
 
         # Write invalid value
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 36).timestamp(),
-                                                      'text': "bla"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 36).timestamp(),
+                    "text": "bla",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn('Invalid', self.api_mock.method_calls[-1][1]['text'])
-        self.assertNotIn('reply_markup', self.api_mock.method_calls[-1][1])  # No change to responseKeyboard expected
+        self.assertIn("Invalid", self.api_mock.method_calls[-1][1]["text"])
+        self.assertNotIn("reply_markup", self.api_mock.method_calls[-1][1])  # No change to responseKeyboard expected
         self.api_mock.reset_mock()
 
         # Write valid 'on' value
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 36).timestamp(),
-                                                      'text': "on"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 36).timestamp(),
+                    "text": "on",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         foo_target._write.assert_called_once_with(True, unittest.mock.ANY)
 
     @async_test
     async def test_read(self) -> None:
-        _foo = self.client.str_connector("Foo", {'max'}, {'max', 'tim'})\
-            .connect(ExampleWritable(str))\
-            .connect(ExampleReadable(str, "hello, world!"))  # noqa: F841
-        _foobar = self.client.generic_connector(int, "Foobar",  # noqa: F841
-                                                lambda x: str(x), lambda x: int(x), {'max', 'alice'},
-                                                options=["0", "5", "15"])\
-            .connect(ExampleWritable(int))\
-            .connect(ExampleReadable(int, 42))  # noqa: F841
-        _bar = self.client.generic_connector(str, "Bar", lambda x: x, lambda x: x, {'alice', 'max'}, {'alice'})\
-            .connect(ExampleWritable(str))  # noqa: F841
+        _foo = (
+            self.client.str_connector("Foo", {"max"}, {"max", "tim"})
+            .connect(ExampleWritable(str))
+            .connect(ExampleReadable(str, "hello, world!"))
+        )  # noqa: F841
+        _foobar = (
+            self.client.generic_connector(
+                int,
+                "Foobar",  # noqa: F841
+                lambda x: str(x),
+                lambda x: int(x),
+                {"max", "alice"},
+                options=["0", "5", "15"],
+            )
+            .connect(ExampleWritable(int))
+            .connect(ExampleReadable(int, 42))
+        )  # noqa: F841
+        _bar = self.client.generic_connector(str, "Bar", lambda x: x, lambda x: x, {"alice", "max"}, {"alice"}).connect(
+            ExampleWritable(str)
+        )  # noqa: F841
 
         await self.api_mock.start()
         self.client_runner.start()
@@ -342,108 +466,166 @@ class TelegramBotTest(unittest.TestCase):
         self.api_mock.reset_mock()
 
         # Search for 'Foo'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
-                                                      'text': "Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 30).timestamp(),
+                    "text": "Foo",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertListEqual([[{'text': "/s Foo"}], [{'text': "/s Foobar"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertListEqual(
+            [[{"text": "/s Foo"}], [{"text": "/s Foobar"}]],
+            json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"],
+        )
         self.api_mock.reset_mock()
 
         # Select 'Foobar'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 35).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn("42", self.api_mock.method_calls[-2][1]['text'])
-        reply_markup = json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])
-        self.assertListEqual([[{'text': "0"}, {'text': "5"}], [{'text': "15"}], [{'text': "/cancel"}]],
-                             reply_markup['keyboard'])
+        self.assertIn("42", self.api_mock.method_calls[-2][1]["text"])
+        reply_markup = json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])
+        self.assertListEqual(
+            [[{"text": "0"}, {"text": "5"}], [{"text": "15"}], [{"text": "/cancel"}]], reply_markup["keyboard"]
+        )
         self.api_mock.reset_mock()
 
         # Cancel and select 'Foo'
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345789,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
-                                                      'text': "/cancel"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345789,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 42).timestamp(),
+                    "text": "/cancel",
+                }
+            }
+        )
 
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345790,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 42, 30).timestamp(),
-                                                      'text': "/s Foo"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345790,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 42, 30).timestamp(),
+                    "text": "/s Foo",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn("hello, world", self.api_mock.method_calls[-2][1]['text'])
-        reply_markup = json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])
-        self.assertListEqual([[{'text': "cancel", 'callback_data': 'cancel'}]], reply_markup['inline_keyboard'])
-        inline_keyboard_message_id = self.api_mock.method_calls[-1][2]['message_id']
+        self.assertIn("hello, world", self.api_mock.method_calls[-2][1]["text"])
+        reply_markup = json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])
+        self.assertListEqual([[{"text": "cancel", "callback_data": "cancel"}]], reply_markup["inline_keyboard"])
+        inline_keyboard_message_id = self.api_mock.method_calls[-1][2]["message_id"]
         self.api_mock.reset_mock()
 
         # Directly (without cancel) select Foobar
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345791,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 43).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345791,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 43).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
 
         await asyncio.sleep(0.3)
         self.assertEqual("editMessageReplyMarkup", self.api_mock.method_calls[0][0])
-        self.assertEqual(str(inline_keyboard_message_id), self.api_mock.method_calls[0][1]['message_id'])
+        self.assertEqual(str(inline_keyboard_message_id), self.api_mock.method_calls[0][1]["message_id"])
 
-        self.assertEqual("987654123", self.api_mock.method_calls[1][1]['chat_id'])
-        self.assertIn("cancelled", self.api_mock.method_calls[1][1]['text'])
+        self.assertEqual("987654123", self.api_mock.method_calls[1][1]["chat_id"])
+        self.assertIn("cancelled", self.api_mock.method_calls[1][1]["text"])
 
-        self.assertEqual("987654123", self.api_mock.method_calls[2][1]['chat_id'])
-        self.assertIn("42", self.api_mock.method_calls[2][1]['text'])
+        self.assertEqual("987654123", self.api_mock.method_calls[2][1]["chat_id"])
+        self.assertIn("42", self.api_mock.method_calls[2][1]["text"])
         self.api_mock.reset_mock()
 
         # Tim can select (and write) but not read
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345792,
-                                                      'from': {'id': 987654789, 'is_bot': False, 'first_name': "Tim"},
-                                                      'chat': {'id': 987654789, 'type': 'private', 'first_name': "Tim"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 44).timestamp(),
-                                                      'text': "/s Foobar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345792,
+                    "from": {"id": 987654789, "is_bot": False, "first_name": "Tim"},
+                    "chat": {"id": 987654789, "type": "private", "first_name": "Tim"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 44).timestamp(),
+                    "text": "/s Foobar",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654789")
-        self.assertNotIn("42", self.api_mock.method_calls[-1][1]['text'])
+        self.assertNotIn("42", self.api_mock.method_calls[-1][1]["text"])
         self.api_mock.reset_mock()
 
         # Max should not see 'Bar', because its not readable, but he es not allowed to write
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345793,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 45).timestamp(),
-                                                      'text': "/cancel"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345793,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 45).timestamp(),
+                    "text": "/cancel",
+                }
+            }
+        )
         await asyncio.sleep(0.15)
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345794,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 45, 20).timestamp(),
-                                                      'text': "Bar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345794,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 45, 20).timestamp(),
+                    "text": "Bar",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_method_called_with("sendMessage", chat_id="987654123")
-        self.assertListEqual([[{'text': "/s Foobar"}]],
-                             json.loads(self.api_mock.method_calls[-1][1]['reply_markup'])['keyboard'])
+        self.assertListEqual(
+            [[{"text": "/s Foobar"}]], json.loads(self.api_mock.method_calls[-1][1]["reply_markup"])["keyboard"]
+        )
         self.api_mock.reset_mock()
 
-        self.api_mock.add_update_for_bot({'message': {'message_id': 12345795,
-                                                      'from': {'id': 987654123, 'is_bot': False, 'first_name': "Max"},
-                                                      'chat': {'id': 987654123, 'type': 'private', 'first_name': "Max"},
-                                                      'date': datetime.datetime(2021, 1, 25, 17, 45).timestamp(),
-                                                      'text': "/s Bar"}})
+        self.api_mock.add_update_for_bot(
+            {
+                "message": {
+                    "message_id": 12345795,
+                    "from": {"id": 987654123, "is_bot": False, "first_name": "Max"},
+                    "chat": {"id": 987654123, "type": "private", "first_name": "Max"},
+                    "date": datetime.datetime(2021, 1, 25, 17, 45).timestamp(),
+                    "text": "/s Bar",
+                }
+            }
+        )
         await asyncio.sleep(0.3)
         self.api_mock.assert_one_method_called_with("sendMessage", chat_id="987654123")
-        self.assertIn("authorized", self.api_mock.method_calls[-1][1]['text'])
+        self.assertIn("authorized", self.api_mock.method_calls[-1][1]["text"])
         self.api_mock.reset_mock()
 
 
@@ -453,17 +635,19 @@ class TelegramAPIMock:
         self.user_object = user_object
 
         self._app = aiohttp.web.Application()
-        self._app.add_routes([
-            aiohttp.web.get("/{token}/getUpdates", self._get_updates),
-            aiohttp.web.post("/{token}/getUpdates", self._get_updates),
-            aiohttp.web.get("/{token}/{method}", self._any_method),
-            aiohttp.web.post("/{token}/{method}", self._any_method),
-        ])
+        self._app.add_routes(
+            [
+                aiohttp.web.get("/{token}/getUpdates", self._get_updates),
+                aiohttp.web.post("/{token}/getUpdates", self._get_updates),
+                aiohttp.web.get("/{token}/{method}", self._any_method),
+                aiohttp.web.post("/{token}/{method}", self._any_method),
+            ]
+        )
 
         self._pending_updates: List[Dict[str, JSON_TYPE]] = []
         self._updates_pending = asyncio.Event()
         self._runner = aiohttp.web.AppRunner(self._app)
-        self.method_calls: List[Tuple[str, Dict[str, Any], Any]] = []   # let's keep the types simple here
+        self.method_calls: List[Tuple[str, Dict[str, Any], Any]] = []  # let's keep the types simple here
         self._next_update_id = 1
 
     async def start(self) -> None:
@@ -475,24 +659,28 @@ class TelegramAPIMock:
         await self._runner.cleanup()
 
     def add_update_for_bot(self, update: Dict[str, JSON_TYPE]) -> None:
-        update['update_id'] = self._next_update_id
+        update["update_id"] = self._next_update_id
         self._pending_updates.append(update)
         self._next_update_id += 1
         self._updates_pending.set()
 
     def assert_method_called_with(self, method: str, **kwargs) -> None:
         assert len(self.method_calls) > 0, "No Telegram API method has been called"
-        assert method == self.method_calls[-1][0], \
-            f"Wrong Telegram API method {self.method_calls[-1][0]} called, expected {method}"
+        assert (
+            method == self.method_calls[-1][0]
+        ), f"Wrong Telegram API method {self.method_calls[-1][0]} called, expected {method}"
         for arg, val in kwargs.items():
             assert arg in self.method_calls[-1][1], f"Expected {arg} in Telegram API method call parameters"
-            assert val == self.method_calls[-1][1][arg], \
-                f"Wrong value '{self.method_calls[-1][1][arg]}' for Parameter {arg}, expected '{val}'"
+            assert (
+                val == self.method_calls[-1][1][arg]
+            ), f"Wrong value '{self.method_calls[-1][1][arg]}' for Parameter {arg}, expected '{val}'"
 
     def assert_method_call_count(self, count: int) -> None:
         actual_count = len(self.method_calls)
-        assert count == actual_count, f"{actual_count} Telegram API methods called " \
-                                      f"({[call[0] for call in self.method_calls]}), expected {count}"
+        assert count == actual_count, (
+            f"{actual_count} Telegram API methods called "
+            f"({[call[0] for call in self.method_calls]}), expected {count}"
+        )
 
     def assert_one_method_called_with(self, method: str, **kwargs):
         self.assert_method_call_count(1)
@@ -512,11 +700,10 @@ class TelegramAPIMock:
 
     async def _get_updates(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
         data = await self.__get_args(request)
-        offset = data.get('offset')
+        offset = data.get("offset")
         if offset is not None:
-            self._pending_updates = [update for update in self._pending_updates
-                                     if update['update_id'] > int(offset)]  # type: ignore
-        timeout = int(data.get('timeout', 0))  # type:  ignore
+            self._pending_updates = [update for update in self._pending_updates if update["update_id"] > int(offset)]  # type: ignore
+        timeout = int(data.get("timeout", 0))  # type:  ignore
         timeout = min(timeout, 1)  # cap timeout to 1 second for faster stopping of tests
         if not self._pending_updates:
             self._updates_pending.clear()
@@ -524,50 +711,55 @@ class TelegramAPIMock:
                 await asyncio.wait_for(self._updates_pending.wait(), timeout)
             except asyncio.TimeoutError:
                 pass
-        updates = self._pending_updates[:data.get('limit', 100)]  # type: ignore
+        updates = self._pending_updates[: data.get("limit", 100)]  # type: ignore
         logger.debug("Updates: %s", updates)
-        return aiohttp.web.json_response({'ok': True, 'result': updates})
+        return aiohttp.web.json_response({"ok": True, "result": updates})
 
     async def _any_method(self, request: aiohttp.web.Request) -> aiohttp.web.Response:
-        method = request.match_info['method']
+        method = request.match_info["method"]
         data = await self.__get_args(request)
         logger.debug("Telegram API method call: %s(%s)", method, data)
         if method == "sendMessage":
             result = self._create_send_message_response(data)
             self.method_calls.append((method, data, result))
-            return aiohttp.web.json_response({'ok': True, 'result': result})
+            return aiohttp.web.json_response({"ok": True, "result": result})
         if method == "editMessageReplyMarkup":
             # We can't create a correct response, b/c we didn't store the message
             self.method_calls.append((method, data, True))
-            return aiohttp.web.json_response({'ok': True, 'result': True})
+            return aiohttp.web.json_response({"ok": True, "result": True})
         if method == "deleteWebhook":
             self.method_calls.append((method, data, True))
-            return aiohttp.web.json_response({'ok': True, 'result': True})
+            return aiohttp.web.json_response({"ok": True, "result": True})
         if method == "getMe":
-            return aiohttp.web.json_response({'ok': True, 'result': {
-                "id": 123456789,
-                "is_bot": True,
-                "first_name": "Test Bot",
-                "language_code": "en",
-                "is_premium": False,
-                "can_join_groups": True,
-                "can_read_all_group_messages": False,
-                "supports_inline_queries": False,
-                "can_connect_to_business": True,
-                "has_main_web_app": False,
-            }})
+            return aiohttp.web.json_response(
+                {
+                    "ok": True,
+                    "result": {
+                        "id": 123456789,
+                        "is_bot": True,
+                        "first_name": "Test Bot",
+                        "language_code": "en",
+                        "is_premium": False,
+                        "can_join_groups": True,
+                        "can_read_all_group_messages": False,
+                        "supports_inline_queries": False,
+                        "can_connect_to_business": True,
+                        "has_main_web_app": False,
+                    },
+                }
+            )
         else:
             self.method_calls.append((method, data, None))
             raise aiohttp.web.HTTPNotImplemented(text=f"Method {method} not implemented.")
 
     def _create_send_message_response(self, data: Dict[str, JSON_TYPE]) -> Dict[str, JSON_TYPE]:
-        if 'text' not in data:
+        if "text" not in data:
             raise aiohttp.web.HTTPNotImplemented(text="Only text messages are implemented in the Mock")
         return {
-            'message_id': random.randint(0, 2**32),
-            'from': self.user_object,
-            'date': round(datetime.datetime.now().timestamp()),
-            'chat': {'id': data['chat_id'], 'type': "private"},  # TODO: more chat info?
-            'text': data['text'],  # We ignore formatting here
+            "message_id": random.randint(0, 2**32),
+            "from": self.user_object,
+            "date": round(datetime.datetime.now().timestamp()),
+            "chat": {"id": data["chat_id"], "type": "private"},  # TODO: more chat info?
+            "text": data["text"],  # We ignore formatting here
             # We also ignore reply to messages (we would need a database of messages to add the relevant info here)
         }

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -5,8 +5,15 @@ import unittest
 import unittest.mock
 from typing import List, Any
 
-from ._helper import async_test, AsyncMock, ExampleReadable, ExampleSubscribable, ExampleWritable, ExampleReading, \
-    SimpleIntRepublisher
+from ._helper import (
+    async_test,
+    AsyncMock,
+    ExampleReadable,
+    ExampleSubscribable,
+    ExampleWritable,
+    ExampleReading,
+    SimpleIntRepublisher,
+)
 from shc import base
 
 
@@ -180,9 +187,7 @@ class TestHandler(unittest.TestCase):
         await part_handler(2, [self, object])
         await empty_handler(3, [self, unittest.mock.sentinel])
         await asyncio.sleep(0.01)
-        mock.assert_has_calls([unittest.mock.call(1, [self]),
-                               unittest.mock.call(2),
-                               unittest.mock.call()])
+        mock.assert_has_calls([unittest.mock.call(1, [self]), unittest.mock.call(2), unittest.mock.call()])
 
 
 class TestBlockingHandler(unittest.TestCase):
@@ -242,9 +247,7 @@ class TestBlockingHandler(unittest.TestCase):
         await part_handler(2, [self, object])
         await empty_handler(3, [self, unittest.mock.sentinel])
         await asyncio.sleep(0.01)
-        mock.assert_has_calls([unittest.mock.call(1, [self]),
-                               unittest.mock.call(2),
-                               unittest.mock.call()])
+        mock.assert_has_calls([unittest.mock.call(1, [self]), unittest.mock.call(2), unittest.mock.call()])
 
 
 class TestReading(unittest.TestCase):
@@ -322,7 +325,7 @@ class TestConnecting(unittest.TestCase):
         a = ExampleSubscribable(int)
         b = ExampleWritable(int)
 
-        with unittest.mock.patch.object(a, 'subscribe') as mock_subscribe:
+        with unittest.mock.patch.object(a, "subscribe") as mock_subscribe:
             a.connect(b, receive=False)  # `read` should not have an effect here
             mock_subscribe.assert_called_once_with(b, convert=False)
 
@@ -349,7 +352,7 @@ class TestConnecting(unittest.TestCase):
         a = ExampleReadable(int, TOTALLY_RANDOM_NUMBER)
         b = ExampleReading(int, False)
 
-        with unittest.mock.patch.object(b, 'set_provider') as mock_set_provider:
+        with unittest.mock.patch.object(b, "set_provider") as mock_set_provider:
             # Since Reading is mandatory, a should be registered with b by default
             a.connect(b, read=False)  # `read=False` should not have an effect here
             mock_set_provider.assert_called_once_with(a, convert=False)
@@ -377,7 +380,7 @@ class TestConnecting(unittest.TestCase):
         a = ExampleReadable(int, TOTALLY_RANDOM_NUMBER)
         b = ExampleReading(int, True)
 
-        with unittest.mock.patch.object(b, 'set_provider') as mock_set_provider:
+        with unittest.mock.patch.object(b, "set_provider") as mock_set_provider:
             a.connect(b)
             mock_set_provider.assert_not_called()
 
@@ -397,8 +400,9 @@ class TestConnecting(unittest.TestCase):
         with self.assertRaises(TypeError):
             b.connect(a)
 
-        with unittest.mock.patch.object(a, 'subscribe') as mock_subscribe, \
-                unittest.mock.patch.object(b, 'set_provider') as mock_set_provider:
+        with unittest.mock.patch.object(a, "subscribe") as mock_subscribe, unittest.mock.patch.object(
+            b, "set_provider"
+        ) as mock_set_provider:
             a.connect(b, convert=True)
             mock_subscribe.assert_called_once_with(b, convert=True)
             mock_set_provider.assert_called_once_with(a, convert=True)
@@ -414,13 +418,14 @@ class TestConnecting(unittest.TestCase):
         b = DummyFloatReadingWritable()
 
         def a2b(x: int) -> float:
-            return float(x/255)
+            return float(x / 255)
 
         def b2a(x: float) -> int:
-            return round(x*255)
+            return round(x * 255)
 
-        with unittest.mock.patch.object(a, 'subscribe') as mock_subscribe, \
-                unittest.mock.patch.object(b, 'set_provider') as mock_set_provider:
+        with unittest.mock.patch.object(a, "subscribe") as mock_subscribe, unittest.mock.patch.object(
+            b, "set_provider"
+        ) as mock_set_provider:
             a.connect(b, convert=(a2b, b2a))
             mock_subscribe.assert_called_once_with(b, convert=a2b)
             mock_set_provider.assert_called_once_with(a, convert=a2b)
@@ -436,10 +441,10 @@ class TestConnecting(unittest.TestCase):
         b = DummyIntWrapper()
 
         def a2b(x: int) -> int:
-            return x*2
+            return x * 2
 
         def b2a(x: int) -> int:
-            return x//2
+            return x // 2
 
         a.connect(b, read=False, provide=True, convert=True)
         b.connect.assert_called_once_with(a, send=None, receive=None, read=True, provide=False, convert=True)

--- a/test/test_conversion.py
+++ b/test/test_conversion.py
@@ -10,10 +10,10 @@ class ConverterRegistrationTest(unittest.TestCase):
         with self.assertRaises(TypeError):
             conversion.get_converter(float, datetime.date)
         with self.assertRaises(TypeError):
-            json.dumps({'var': Variable(bool)}, cls=conversion.SHCJsonEncoder)
+            json.dumps({"var": Variable(bool)}, cls=conversion.SHCJsonEncoder)
         with self.assertRaises(TypeError):
-            fake_json_data = {'var': {'x': 'foobar'}}
-            conversion.from_json(Variable, fake_json_data['var'])
+            fake_json_data = {"var": {"x": "foobar"}}
+            conversion.from_json(Variable, fake_json_data["var"])
 
 
 class DefaultConverterTest(unittest.TestCase):
@@ -30,26 +30,30 @@ class DefaultConverterTest(unittest.TestCase):
     def test_default_json_converters(self) -> None:
         date1 = datetime.date(2020, 5, 17)
         datetime1 = datetime.datetime(2020, 5, 17, 17, 35, 19, 5005)
-        datetime2 = datetime.datetime(2020, 5, 17, 17, 35, 19, 5005,
-                                      tzinfo=datetime.timezone(datetime.timedelta(hours=2)))
+        datetime2 = datetime.datetime(
+            2020, 5, 17, 17, 35, 19, 5005, tzinfo=datetime.timezone(datetime.timedelta(hours=2))
+        )
         timedelta1 = datetime.timedelta(days=5, hours=7, minutes=3, milliseconds=25)
 
-        serialized = json.dumps({
-            'int': 5,
-            'bool': True,
-            'float': 5.3,
-            'date1': date1,
-            'datetime1': datetime1,
-            'datetime2': datetime2,
-            'timedelta1': timedelta1,
-        }, cls=conversion.SHCJsonEncoder)
+        serialized = json.dumps(
+            {
+                "int": 5,
+                "bool": True,
+                "float": 5.3,
+                "date1": date1,
+                "datetime1": datetime1,
+                "datetime2": datetime2,
+                "timedelta1": timedelta1,
+            },
+            cls=conversion.SHCJsonEncoder,
+        )
 
         deserialized = json.loads(serialized)
 
-        self.assertEqual(5, conversion.from_json(int, deserialized['int']))
-        self.assertEqual(True, conversion.from_json(bool, deserialized['bool']))
-        self.assertEqual(5.3, conversion.from_json(float, deserialized['float']))
-        self.assertEqual(date1, conversion.from_json(datetime.date, deserialized['date1']))
-        self.assertEqual(datetime1, conversion.from_json(datetime.datetime, deserialized['datetime1']))
-        self.assertEqual(datetime2, conversion.from_json(datetime.datetime, deserialized['datetime2']))
-        self.assertEqual(timedelta1, conversion.from_json(datetime.timedelta, deserialized['timedelta1']))
+        self.assertEqual(5, conversion.from_json(int, deserialized["int"]))
+        self.assertEqual(True, conversion.from_json(bool, deserialized["bool"]))
+        self.assertEqual(5.3, conversion.from_json(float, deserialized["float"]))
+        self.assertEqual(date1, conversion.from_json(datetime.date, deserialized["date1"]))
+        self.assertEqual(datetime1, conversion.from_json(datetime.datetime, deserialized["datetime1"]))
+        self.assertEqual(datetime2, conversion.from_json(datetime.datetime, deserialized["datetime2"]))
+        self.assertEqual(timedelta1, conversion.from_json(datetime.timedelta, deserialized["timedelta1"]))

--- a/test/test_data_logging.py
+++ b/test/test_data_logging.py
@@ -31,8 +31,9 @@ class ExampleLogVariable(shc.data_logging.DataLogVariable[T], Generic[T]):
         self.type = type(time_series[0][1])
         self.data = time_series
 
-    async def retrieve_log(self, start_time: datetime.datetime, end_time: datetime.datetime,
-                           include_previous: bool = True) -> List[Tuple[datetime.datetime, T]]:
+    async def retrieve_log(
+        self, start_time: datetime.datetime, end_time: datetime.datetime, include_previous: bool = True
+    ) -> List[Tuple[datetime.datetime, T]]:
         return self.data
 
 
@@ -49,58 +50,81 @@ class AbstractLoggingTest(unittest.TestCase):
     do_subscribe_tests: bool = False
 
     # Override this method in a derived test case class to run these tests for an actual DataLogVariable implementation
-    async def _create_log_variable_with_data(self, _type: Type[T], data: Iterable[Tuple[datetime.datetime, T]]) \
-            -> shc.data_logging.DataLogVariable[T]:
+    async def _create_log_variable_with_data(
+        self, _type: Type[T], data: Iterable[Tuple[datetime.datetime, T]]
+    ) -> shc.data_logging.DataLogVariable[T]:
         return ExampleLogVariable(list(data))
 
     @async_test
     async def test_maxmin_aggregation(self) -> None:
         variable = await self._create_log_variable_with_data(float, time_series_1)
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.MAXIMUM,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.MAXIMUM,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(2, len(result))
         self.assertAlmostEqual(40.0, result[0][1])
         self.assertAlmostEqual(40.0, result[1][1])
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(), result[0][0],
-                               delta=datetime.timedelta(milliseconds=10))
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(), result[1][0],
-                               delta=datetime.timedelta(milliseconds=10))
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            result[0][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
+            result[1][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(2, len(result))
         self.assertAlmostEqual(20.0, result[0][1])
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(1, len(result))
         self.assertAlmostEqual(20.0, result[0][1])
 
     @async_test
     async def test_average_aggregation(self) -> None:
         variable = await self._create_log_variable_with_data(float, time_series_1)
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(2, len(result))
         self.assertAlmostEqual(30.0, result[0][1])
         self.assertAlmostEqual(28.0, result[1][1])
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(), result[0][0],
-                               delta=datetime.timedelta(milliseconds=10))
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(), result[1][0],
-                               delta=datetime.timedelta(milliseconds=10))
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            result[0][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
+            result[1][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 25).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 25).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(10, len(result))
         self.assertAlmostEqual(32.0, result[0][1])  # 25
         self.assertAlmostEqual(40.0, result[1][1])
@@ -109,17 +133,21 @@ class AbstractLoggingTest(unittest.TestCase):
         self.assertAlmostEqual(20.0, result[4][1])  # 35
         self.assertAlmostEqual(20.0, result[5][1])
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(1, len(result))
         self.assertAlmostEqual(30.0, result[0][1])
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(4, len(result))
         self.assertAlmostEqual(40.0, result[0][1])
         self.assertAlmostEqual(40.0, result[1][1])
@@ -129,22 +157,32 @@ class AbstractLoggingTest(unittest.TestCase):
     @async_test
     async def test_ontime_aggregation(self) -> None:
         variable = await self._create_log_variable_with_data(bool, time_series_2)
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
-                                                        aggregation_interval=datetime.timedelta(seconds=10))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 30).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(2, len(result))
         self.assertAlmostEqual(5.0, result[0][1])
         self.assertAlmostEqual(4.0, result[1][1])
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(), result[0][0],
-                               delta=datetime.timedelta(milliseconds=10))
-        self.assertAlmostEqual(datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(), result[1][0],
-                               delta=datetime.timedelta(milliseconds=10))
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
+            result[0][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
+        self.assertAlmostEqual(
+            datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
+            result[1][0],
+            delta=datetime.timedelta(milliseconds=10),
+        )
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 25).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 25).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(10, len(result))
         self.assertAlmostEqual(1.5, result[0][1])
         self.assertAlmostEqual(2.5, result[1][1])
@@ -157,7 +195,8 @@ class AbstractLoggingTest(unittest.TestCase):
             start_time=datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone(),
             end_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
             aggregation_method=shc.data_logging.AggregationMethod.ON_TIME_RATIO,
-            aggregation_interval=datetime.timedelta(seconds=10))
+            aggregation_interval=datetime.timedelta(seconds=10),
+        )
         self.assertEqual(1, len(result))
         self.assertAlmostEqual(0.5, result[0][1])
 
@@ -165,7 +204,8 @@ class AbstractLoggingTest(unittest.TestCase):
             start_time=datetime.datetime(2020, 1, 1, 0, 0, 10).astimezone(),
             end_time=datetime.datetime(2020, 1, 1, 0, 0, 20).astimezone(),
             aggregation_method=shc.data_logging.AggregationMethod.ON_TIME_RATIO,
-            aggregation_interval=datetime.timedelta(seconds=2.5))
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(4, len(result))
         self.assertAlmostEqual(1.0, result[0][1])
         self.assertAlmostEqual(1.0, result[1][1])
@@ -175,17 +215,21 @@ class AbstractLoggingTest(unittest.TestCase):
     @async_test
     async def test_empty_aggregation(self) -> None:
         variable = await self._create_log_variable_with_data(float, time_series_1)
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(4, len(result))
         self.assertEqual(20.0, result[0][1])
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
-                                                        end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
+            end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(4, len(result))
         self.assertEqual(20.0, result[0][1])
 
@@ -193,36 +237,45 @@ class AbstractLoggingTest(unittest.TestCase):
             start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
             end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
             aggregation_method=shc.data_logging.AggregationMethod.ON_TIME_RATIO,
-            aggregation_interval=datetime.timedelta(seconds=2.5))
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(4, len(result))
         self.assertEqual(1.0, result[0][1])
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
-                                                        end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.MAXIMUM,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
+            end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.MAXIMUM,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(0, len(result))
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
-                                                        end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
+            end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.AVERAGE,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(0, len(result))
 
-        result = await variable.retrieve_aggregated_log(start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
-                                                        end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
-                                                        aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
-                                                        aggregation_interval=datetime.timedelta(seconds=2.5))
+        result = await variable.retrieve_aggregated_log(
+            start_time=datetime.datetime(2019, 1, 1, 0, 0, 40).astimezone(),
+            end_time=datetime.datetime(2019, 1, 1, 0, 0, 50).astimezone(),
+            aggregation_method=shc.data_logging.AggregationMethod.ON_TIME,
+            aggregation_interval=datetime.timedelta(seconds=2.5),
+        )
         self.assertEqual(0, len(result))
 
     @async_test
     async def test_aggregation_type_error(self) -> None:
         variable = await self._create_log_variable_with_data(str, [(datetime.datetime(2020, 1, 1, 0, 0, 0), "foo")])
         with self.assertRaises(TypeError):
-            await variable.retrieve_aggregated_log(start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
-                                                   end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
-                                                   aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
-                                                   aggregation_interval=datetime.timedelta(seconds=2.5))
+            await variable.retrieve_aggregated_log(
+                start_time=datetime.datetime(2020, 1, 1, 0, 0, 40).astimezone(),
+                end_time=datetime.datetime(2020, 1, 1, 0, 0, 50).astimezone(),
+                aggregation_method=shc.data_logging.AggregationMethod.MINIMUM,
+                aggregation_interval=datetime.timedelta(seconds=2.5),
+            )
 
     @async_test
     async def test_simple_write_and_retrieval(self) -> None:
@@ -241,21 +294,23 @@ class AbstractLoggingTest(unittest.TestCase):
         await var1.write(5, [self])  # type: ignore
 
         # Check data retrieval (with include_previous)
-        data = await var1.retrieve_log(start_ts + datetime.timedelta(seconds=0.1),
-                                       start_ts + datetime.timedelta(days=200),
-                                       include_previous=True)
+        data = await var1.retrieve_log(
+            start_ts + datetime.timedelta(seconds=0.1), start_ts + datetime.timedelta(days=200), include_previous=True
+        )
         self.assertEqual(5, len(data))
 
         # Check data retrieval (without include_previous)
-        data = await var1.retrieve_log(start_ts + datetime.timedelta(seconds=0.1),
-                                       start_ts + datetime.timedelta(days=200),
-                                       include_previous=False)
+        data = await var1.retrieve_log(
+            start_ts + datetime.timedelta(seconds=0.1), start_ts + datetime.timedelta(days=200), include_previous=False
+        )
         self.assertEqual(4, len(data))
         self.assertListEqual([2, 3, 4, 5], [v for _ts, v in data])
-        self.assertAlmostEqual(data[0][0], start_ts + datetime.timedelta(seconds=0.2),
-                               delta=datetime.timedelta(milliseconds=400))
-        self.assertAlmostEqual(data[-1][0], start_ts + datetime.timedelta(seconds=1.05),
-                               delta=datetime.timedelta(milliseconds=400))
+        self.assertAlmostEqual(
+            data[0][0], start_ts + datetime.timedelta(seconds=0.2), delta=datetime.timedelta(milliseconds=400)
+        )
+        self.assertAlmostEqual(
+            data[-1][0], start_ts + datetime.timedelta(seconds=1.05), delta=datetime.timedelta(milliseconds=400)
+        )
 
         # Check reading
         self.assertEqual(5, await var1.read())  # type: ignore
@@ -312,14 +367,16 @@ class AbstractLoggingTest(unittest.TestCase):
             # Reset view1's result to current state, as returned by var1 (as if we are a client that connected just now)
             view1.result = await var1.retrieve_log_sync(
                 datetime.datetime.now().astimezone() - datetime.timedelta(seconds=20),
-                datetime.datetime.now().astimezone())
+                datetime.datetime.now().astimezone(),
+            )
 
         async def consumer2() -> None:
             await asyncio.sleep(0.3)
             # Reset view2's result to current state, as returned by var1 (as if we are a client that connected just now)
             view2.result = await var1.retrieve_log_sync(
                 datetime.datetime.now().astimezone() - datetime.timedelta(seconds=20),
-                datetime.datetime.now().astimezone())
+                datetime.datetime.now().astimezone(),
+            )
 
         await asyncio.gather(producer(), consumer1(), consumer2())
 
@@ -329,6 +386,7 @@ class AbstractLoggingTest(unittest.TestCase):
 
 class SimpleInMemoryLogVariable(shc.data_logging.DataLogVariable[T], Readable[T], Generic[T]):
     """A more sophisticated ExampleLogVariable, including range filtering in retrieve_log"""
+
     type: Type[T]
 
     def __init__(self, type_: Type[T]):
@@ -341,8 +399,9 @@ class SimpleInMemoryLogVariable(shc.data_logging.DataLogVariable[T], Readable[T]
             raise UninitializedError("No value has been persisted yet")
         return self.data[-1][1]
 
-    async def retrieve_log(self, start_time: datetime.datetime, end_time: datetime.datetime,
-                           include_previous: bool = False) -> List[Tuple[datetime.datetime, T]]:
+    async def retrieve_log(
+        self, start_time: datetime.datetime, end_time: datetime.datetime, include_previous: bool = False
+    ) -> List[Tuple[datetime.datetime, T]]:
         iterator = iter(enumerate(self.data))
         try:
             start_index = next(i for i, (ts, _v) in iterator if ts >= start_time)
@@ -353,7 +412,7 @@ class SimpleInMemoryLogVariable(shc.data_logging.DataLogVariable[T], Readable[T]
                 return []
         if self.data[start_index][0] >= end_time:
             if include_previous and self.data:
-                return self.data[start_index:start_index+1]
+                return self.data[start_index : start_index + 1]
             else:
                 return []
         if include_previous and start_index > 0:
@@ -365,12 +424,14 @@ class SimpleInMemoryLogVariable(shc.data_logging.DataLogVariable[T], Readable[T]
         return self.data[start_index:end_index]
 
 
-class SimpleInMemoryWritableLogVariable(SimpleInMemoryLogVariable[T], shc.data_logging.WritableDataLogVariable[T],
-                                        Generic[T]):
+class SimpleInMemoryWritableLogVariable(
+    SimpleInMemoryLogVariable[T], shc.data_logging.WritableDataLogVariable[T], Generic[T]
+):
     type: Type[T]
 
     """A simplified version of InMemoryDataLogVariable, based on WritableDataLogVariable to test its subscribe
     mechanism"""
+
     def __init__(self, type_: Type[T]):
         super().__init__(type_)
 
@@ -382,21 +443,24 @@ class WritableDataLogVariableTest(AbstractLoggingTest):
     do_write_tests = True
     do_subscribe_tests = True
 
-    async def _create_log_variable_with_data(self, type_: Type[T], data: Iterable[Tuple[datetime.datetime, T]]) \
-            -> shc.data_logging.DataLogVariable[T]:
+    async def _create_log_variable_with_data(
+        self, type_: Type[T], data: Iterable[Tuple[datetime.datetime, T]]
+    ) -> shc.data_logging.DataLogVariable[T]:
         var = SimpleInMemoryWritableLogVariable(type_)
         var.data = list(data)
         return var
 
 
 class ExampleLiveDataLogView(shc.data_logging.LiveDataLogView[T], Generic[T]):
-    def __init__(self,
-                 data_log: shc.data_logging.DataLogVariable[T],
-                 interval: datetime.timedelta,
-                 aggregation: Optional[shc.data_logging.AggregationMethod] = None,
-                 aggregation_interval: Optional[datetime.timedelta] = None,
-                 align_to: datetime.datetime = datetime.datetime(2020, 1, 1, 0, 0, 0),
-                 update_interval: Optional[datetime.timedelta] = None):
+    def __init__(
+        self,
+        data_log: shc.data_logging.DataLogVariable[T],
+        interval: datetime.timedelta,
+        aggregation: Optional[shc.data_logging.AggregationMethod] = None,
+        aggregation_interval: Optional[datetime.timedelta] = None,
+        align_to: datetime.datetime = datetime.datetime(2020, 1, 1, 0, 0, 0),
+        update_interval: Optional[datetime.timedelta] = None,
+    ):
         super().__init__(data_log, interval, aggregation, aggregation_interval, align_to, update_interval)
         self.clients: Dict[str, List[Tuple[datetime.datetime, Union[T, float]]]] = {}
 
@@ -415,9 +479,9 @@ class LiveDataLogViewTest(unittest.TestCase):
     async def test_not_subscribable(self) -> None:
         log_var = SimpleInMemoryLogVariable(float)
         log_var.data = time_series_1
-        view = ExampleLiveDataLogView(log_var,
-                                      interval=datetime.timedelta(seconds=30),
-                                      update_interval=datetime.timedelta(seconds=2))
+        view = ExampleLiveDataLogView(
+            log_var, interval=datetime.timedelta(seconds=30), update_interval=datetime.timedelta(seconds=2)
+        )
 
         try:
             with ClockMock(datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone()):
@@ -437,9 +501,9 @@ class LiveDataLogViewTest(unittest.TestCase):
     async def test_not_subscribable_two_clients(self) -> None:
         log_var = SimpleInMemoryLogVariable(float)
         log_var.data = time_series_1
-        view = ExampleLiveDataLogView(log_var,
-                                      interval=datetime.timedelta(seconds=30),
-                                      update_interval=datetime.timedelta(seconds=10))
+        view = ExampleLiveDataLogView(
+            log_var, interval=datetime.timedelta(seconds=30), update_interval=datetime.timedelta(seconds=10)
+        )
 
         try:
             with ClockMock(datetime.datetime(2020, 1, 1, 0, 0, 0).astimezone()):
@@ -462,9 +526,9 @@ class LiveDataLogViewTest(unittest.TestCase):
     async def test_push(self) -> None:
         log_var = SimpleInMemoryWritableLogVariable(float)
         log_var.data = time_series_1
-        view = ExampleLiveDataLogView(log_var,
-                                      interval=datetime.timedelta(seconds=30),
-                                      update_interval=datetime.timedelta(seconds=2))
+        view = ExampleLiveDataLogView(
+            log_var, interval=datetime.timedelta(seconds=30), update_interval=datetime.timedelta(seconds=2)
+        )
 
         async def pusher():
             for t, v in time_series_1:
@@ -489,9 +553,9 @@ class LiveDataLogViewTest(unittest.TestCase):
     async def test_push_two_clients(self) -> None:
         log_var = SimpleInMemoryWritableLogVariable(float)
         log_var.data = time_series_1
-        view = ExampleLiveDataLogView(log_var,
-                                      interval=datetime.timedelta(seconds=30),
-                                      update_interval=datetime.timedelta(seconds=10))
+        view = ExampleLiveDataLogView(
+            log_var, interval=datetime.timedelta(seconds=30), update_interval=datetime.timedelta(seconds=10)
+        )
 
         async def pusher():
             for t, v in time_series_1:

--- a/test/test_datatypes.py
+++ b/test/test_datatypes.py
@@ -1,4 +1,3 @@
-
 import unittest
 
 from shc import datatypes, conversion
@@ -79,26 +78,26 @@ class ConversionTests(unittest.TestCase):
         self.assertEqual(datatypes.RangeFloat1(1.0), conversion.get_converter(bool, datatypes.RangeFloat1)(True))
 
     def test_rgb(self) -> None:
-        some_blue = datatypes.RGBFloat1(datatypes.RangeFloat1(.25),
-                                        datatypes.RangeFloat1(.5),
-                                        datatypes.RangeFloat1(.75))
+        some_blue = datatypes.RGBFloat1(
+            datatypes.RangeFloat1(0.25), datatypes.RangeFloat1(0.5), datatypes.RangeFloat1(0.75)
+        )
         some_blue_int = conversion.get_converter(datatypes.RGBFloat1, datatypes.RGBUInt8)(some_blue)
-        self.assertEqual(datatypes.RGBUInt8(datatypes.RangeUInt8(64),
-                                            datatypes.RangeUInt8(128),
-                                            datatypes.RangeUInt8(191)),
-                         some_blue_int)
+        self.assertEqual(
+            datatypes.RGBUInt8(datatypes.RangeUInt8(64), datatypes.RangeUInt8(128), datatypes.RangeUInt8(191)),
+            some_blue_int,
+        )
 
         some_blue_hsv = conversion.get_converter(datatypes.RGBFloat1, datatypes.HSVFloat1)(some_blue)
-        self.assertAlmostEqual(210/360, some_blue_hsv.hue, delta=0.01)
+        self.assertAlmostEqual(210 / 360, some_blue_hsv.hue, delta=0.01)
         self.assertAlmostEqual(0.6667, some_blue_hsv.saturation, delta=0.01)
         self.assertAlmostEqual(0.75, some_blue_hsv.value, delta=0.01)
 
         some_blue_hsv2 = conversion.get_converter(datatypes.RGBUInt8, datatypes.HSVFloat1)(some_blue_int)
-        self.assertAlmostEqual(210/360, some_blue_hsv2.hue, delta=0.01)
+        self.assertAlmostEqual(210 / 360, some_blue_hsv2.hue, delta=0.01)
         self.assertAlmostEqual(0.6667, some_blue_hsv2.saturation, delta=0.01)
         self.assertAlmostEqual(0.75, some_blue_hsv2.value, delta=0.01)
 
-        some_yellow_hsv = some_blue_hsv._replace(hue=datatypes.RangeFloat1(45/360))
+        some_yellow_hsv = some_blue_hsv._replace(hue=datatypes.RangeFloat1(45 / 360))
 
         some_yellow = conversion.get_converter(datatypes.HSVFloat1, datatypes.RGBFloat1)(some_yellow_hsv)
         self.assertAlmostEqual(0.75, some_yellow.red, delta=0.01)
@@ -106,10 +105,10 @@ class ConversionTests(unittest.TestCase):
         self.assertAlmostEqual(0.25, some_yellow.blue, delta=0.01)
 
         some_yellow_int = conversion.get_converter(datatypes.HSVFloat1, datatypes.RGBUInt8)(some_yellow_hsv)
-        self.assertEqual(datatypes.RGBUInt8(datatypes.RangeUInt8(191),
-                                            datatypes.RangeUInt8(159),
-                                            datatypes.RangeUInt8(64)),
-                         some_yellow_int)
+        self.assertEqual(
+            datatypes.RGBUInt8(datatypes.RangeUInt8(191), datatypes.RangeUInt8(159), datatypes.RangeUInt8(64)),
+            some_yellow_int,
+        )
 
         some_yellow2 = conversion.get_converter(datatypes.RGBUInt8, datatypes.RGBFloat1)(some_yellow_int)
         self.assertAlmostEqual(0.75, some_yellow2.red, delta=0.01)
@@ -117,100 +116,111 @@ class ConversionTests(unittest.TestCase):
         self.assertAlmostEqual(0.25, some_yellow2.blue, delta=0.01)
 
     def test_cct_and_rgbw(self) -> None:
-        some_blue_int = datatypes.RGBUInt8(datatypes.RangeUInt8(64),
-                                           datatypes.RangeUInt8(128),
-                                           datatypes.RangeUInt8(191))
+        some_blue_int = datatypes.RGBUInt8(
+            datatypes.RangeUInt8(64), datatypes.RangeUInt8(128), datatypes.RangeUInt8(191)
+        )
         some_blue_rgbw = conversion.get_converter(datatypes.RGBUInt8, datatypes.RGBWUInt8)(some_blue_int)
-        self.assertEqual(datatypes.RGBWUInt8(some_blue_int, datatypes.RangeUInt8(0)),
-                         some_blue_rgbw)
+        self.assertEqual(datatypes.RGBWUInt8(some_blue_int, datatypes.RangeUInt8(0)), some_blue_rgbw)
 
         some_blue_with_white = some_blue_rgbw._replace(white=datatypes.RangeUInt8(133))
-        self.assertEqual(some_blue_int,
-                         conversion.get_converter(datatypes.RGBWUInt8, datatypes.RGBUInt8)(some_blue_with_white))
+        self.assertEqual(
+            some_blue_int, conversion.get_converter(datatypes.RGBWUInt8, datatypes.RGBUInt8)(some_blue_with_white)
+        )
 
-        some_blue_with_cct = \
-            conversion.get_converter(datatypes.RGBWUInt8, datatypes.RGBCCTUInt8)(some_blue_with_white)
-        self.assertEqual(datatypes.RGBCCTUInt8(some_blue_int, datatypes.CCTUInt8(datatypes.RangeUInt8(133),
-                                                                                 datatypes.RangeUInt8(133))),
-                         some_blue_with_cct)
+        some_blue_with_cct = conversion.get_converter(datatypes.RGBWUInt8, datatypes.RGBCCTUInt8)(some_blue_with_white)
+        self.assertEqual(
+            datatypes.RGBCCTUInt8(
+                some_blue_int, datatypes.CCTUInt8(datatypes.RangeUInt8(133), datatypes.RangeUInt8(133))
+            ),
+            some_blue_with_cct,
+        )
 
         some_blue_with_white_other_cct = some_blue_with_cct._replace(
-            white=datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153)))
-        self.assertEqual(some_blue_with_white,
-                         conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.RGBWUInt8)
-                         (some_blue_with_white_other_cct))
+            white=datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153))
+        )
+        self.assertEqual(
+            some_blue_with_white,
+            conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.RGBWUInt8)(some_blue_with_white_other_cct),
+        )
 
-        self.assertEqual(datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153)),
-                         conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.CCTUInt8)
-                         (some_blue_with_white_other_cct))
+        self.assertEqual(
+            datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153)),
+            conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.CCTUInt8)(some_blue_with_white_other_cct),
+        )
 
-        self.assertEqual(some_blue_int,
-                         conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.RGBUInt8)
-                         (some_blue_with_cct))
+        self.assertEqual(
+            some_blue_int, conversion.get_converter(datatypes.RGBCCTUInt8, datatypes.RGBUInt8)(some_blue_with_cct)
+        )
 
-        self.assertEqual(datatypes.RangeUInt8(133),
-                         conversion.get_converter(datatypes.CCTUInt8, datatypes.RangeUInt8)
-                         (datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153))))
-        self.assertEqual(datatypes.CCTUInt8(datatypes.RangeUInt8(133), datatypes.RangeUInt8(133)),
-                         conversion.get_converter(datatypes.RangeUInt8, datatypes.CCTUInt8)
-                         (datatypes.RangeUInt8(133)))
+        self.assertEqual(
+            datatypes.RangeUInt8(133),
+            conversion.get_converter(datatypes.CCTUInt8, datatypes.RangeUInt8)(
+                datatypes.CCTUInt8(datatypes.RangeUInt8(113), datatypes.RangeUInt8(153))
+            ),
+        )
+        self.assertEqual(
+            datatypes.CCTUInt8(datatypes.RangeUInt8(133), datatypes.RangeUInt8(133)),
+            conversion.get_converter(datatypes.RangeUInt8, datatypes.CCTUInt8)(datatypes.RangeUInt8(133)),
+        )
 
 
 class ColorTests(unittest.TestCase):
     def test_rgb_scaling(self) -> None:
-        some_blue = datatypes.RGBFloat1(datatypes.RangeFloat1(.25),
-                                        datatypes.RangeFloat1(.5),
-                                        datatypes.RangeFloat1(.75))
+        some_blue = datatypes.RGBFloat1(
+            datatypes.RangeFloat1(0.25), datatypes.RangeFloat1(0.5), datatypes.RangeFloat1(0.75)
+        )
 
         some_dim_blue = some_blue.dimmed(datatypes.RangeFloat1(0.5))
-        self.assertAlmostEqual(some_dim_blue.red, .125)
-        self.assertAlmostEqual(some_dim_blue.green, .25)
-        self.assertAlmostEqual(some_dim_blue.blue, .375)
+        self.assertAlmostEqual(some_dim_blue.red, 0.125)
+        self.assertAlmostEqual(some_dim_blue.green, 0.25)
+        self.assertAlmostEqual(some_dim_blue.blue, 0.375)
 
         some_dim_blue2 = some_blue.dimmed(datatypes.RangeInt0To100(50))
-        self.assertAlmostEqual(some_dim_blue2.red, .125, delta=0.01)
-        self.assertAlmostEqual(some_dim_blue2.green, .25, delta=0.01)
-        self.assertAlmostEqual(some_dim_blue2.blue, .375, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue2.red, 0.125, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue2.green, 0.25, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue2.blue, 0.375, delta=0.01)
 
         some_dim_blue3 = some_blue.dimmed(datatypes.RangeUInt8(127))
-        self.assertAlmostEqual(some_dim_blue3.red, .125, delta=0.01)
-        self.assertAlmostEqual(some_dim_blue3.green, .25, delta=0.01)
-        self.assertAlmostEqual(some_dim_blue3.blue, .375, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue3.red, 0.125, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue3.green, 0.25, delta=0.01)
+        self.assertAlmostEqual(some_dim_blue3.blue, 0.375, delta=0.01)
 
-        some_blue_hsv = datatypes.HSVFloat1(datatypes.RangeFloat1(210/360),
-                                            datatypes.RangeFloat1(.6667),
-                                            datatypes.RangeFloat1(.75))
+        some_blue_hsv = datatypes.HSVFloat1(
+            datatypes.RangeFloat1(210 / 360), datatypes.RangeFloat1(0.6667), datatypes.RangeFloat1(0.75)
+        )
 
         some_dim_hsv_blue = some_blue_hsv.dimmed(datatypes.RangeFloat1(0.5))
-        self.assertAlmostEqual(some_dim_hsv_blue.hue, 210/360)
-        self.assertAlmostEqual(some_dim_hsv_blue.saturation, .6667)
-        self.assertAlmostEqual(some_dim_hsv_blue.value, .375)
+        self.assertAlmostEqual(some_dim_hsv_blue.hue, 210 / 360)
+        self.assertAlmostEqual(some_dim_hsv_blue.saturation, 0.6667)
+        self.assertAlmostEqual(some_dim_hsv_blue.value, 0.375)
 
         some_dim_hsv_blue2 = some_blue_hsv.dimmed(datatypes.RangeInt0To100(50))
-        self.assertAlmostEqual(some_dim_hsv_blue2.value, .375, delta=0.01)
+        self.assertAlmostEqual(some_dim_hsv_blue2.value, 0.375, delta=0.01)
 
         some_dim_hsv_blue3 = some_blue_hsv.dimmed(datatypes.RangeUInt8(127))
-        self.assertAlmostEqual(some_dim_hsv_blue3.value, .375, delta=0.01)
+        self.assertAlmostEqual(some_dim_hsv_blue3.value, 0.375, delta=0.01)
 
     def test_rgbw_scaling(self) -> None:
-        some_blue_with_white = datatypes.RGBWUInt8(datatypes.RGBUInt8(datatypes.RangeUInt8(64),
-                                                                      datatypes.RangeUInt8(128),
-                                                                      datatypes.RangeUInt8(191)),
-                                                   datatypes.RangeUInt8(133))
-        self.assertEqual(datatypes.RGBWUInt8(datatypes.RGBUInt8(datatypes.RangeUInt8(32),
-                                                                datatypes.RangeUInt8(64),
-                                                                datatypes.RangeUInt8(96)),
-                                             datatypes.RangeUInt8(66)),
-                         some_blue_with_white.dimmed(datatypes.RangeFloat1(0.5)))
+        some_blue_with_white = datatypes.RGBWUInt8(
+            datatypes.RGBUInt8(datatypes.RangeUInt8(64), datatypes.RangeUInt8(128), datatypes.RangeUInt8(191)),
+            datatypes.RangeUInt8(133),
+        )
+        self.assertEqual(
+            datatypes.RGBWUInt8(
+                datatypes.RGBUInt8(datatypes.RangeUInt8(32), datatypes.RangeUInt8(64), datatypes.RangeUInt8(96)),
+                datatypes.RangeUInt8(66),
+            ),
+            some_blue_with_white.dimmed(datatypes.RangeFloat1(0.5)),
+        )
 
-        some_blue_with_cct = datatypes.RGBCCTUInt8(datatypes.RGBUInt8(datatypes.RangeUInt8(64),
-                                                                      datatypes.RangeUInt8(128),
-                                                                      datatypes.RangeUInt8(191)),
-                                                   datatypes.CCTUInt8(datatypes.RangeUInt8(133),
-                                                                      datatypes.RangeUInt8(118)))
-        self.assertEqual(datatypes.RGBCCTUInt8(datatypes.RGBUInt8(datatypes.RangeUInt8(32),
-                                                                  datatypes.RangeUInt8(64),
-                                                                  datatypes.RangeUInt8(96)),
-                                               datatypes.CCTUInt8(datatypes.RangeUInt8(66),
-                                                                  datatypes.RangeUInt8(59))),
-                         some_blue_with_cct.dimmed(datatypes.RangeFloat1(0.5)))
+        some_blue_with_cct = datatypes.RGBCCTUInt8(
+            datatypes.RGBUInt8(datatypes.RangeUInt8(64), datatypes.RangeUInt8(128), datatypes.RangeUInt8(191)),
+            datatypes.CCTUInt8(datatypes.RangeUInt8(133), datatypes.RangeUInt8(118)),
+        )
+        self.assertEqual(
+            datatypes.RGBCCTUInt8(
+                datatypes.RGBUInt8(datatypes.RangeUInt8(32), datatypes.RangeUInt8(64), datatypes.RangeUInt8(96)),
+                datatypes.CCTUInt8(datatypes.RangeUInt8(66), datatypes.RangeUInt8(59)),
+            ),
+            some_blue_with_cct.dimmed(datatypes.RangeFloat1(0.5)),
+        )

--- a/test/test_examples.py
+++ b/test/test_examples.py
@@ -14,12 +14,14 @@ class BasicTest(unittest.TestCase):
     def test_ui_showcase(self) -> None:
         shc.supervisor.event_loop.create_task(shutdown())
         import example.ui_showcase  # type: ignore  # noqa: F401
+
         shc.main()
 
     def test_ui_logging_showcase(self) -> None:
         shc.supervisor.event_loop.create_task(shutdown())
 
         import example.ui_logging_showcase  # type: ignore  # noqa: F401
+
         shc.main()
 
     def test_server_client_example(self) -> None:
@@ -28,6 +30,7 @@ class BasicTest(unittest.TestCase):
         # The examples should actually be able to coexist in a single SHC instance
         import example.server_client.server  # type: ignore  # noqa: F401
         import example.server_client.client  # type: ignore  # noqa: F401
+
         shc.main()
 
     def test_tasmota_led_example(self) -> None:

--- a/test/test_expressions.py
+++ b/test/test_expressions.py
@@ -88,7 +88,7 @@ class TestExpressions(unittest.TestCase):
         with self.assertRaises(TypeError):
             5.5 * var2.EX
         with self.assertRaises(TypeError):
-            (- var2.EX)
+            (-var2.EX)
         with self.assertRaises(TypeError):
             abs(var2.EX)
         with self.assertRaises(TypeError):

--- a/test/test_variables.py
+++ b/test/test_variables.py
@@ -13,8 +13,7 @@ from ._helper import async_test, ExampleReadable, ExampleWritable
 
 
 class SimpleVariableTest(unittest.TestCase):
-
-    @unittest.mock.patch('shc.variables.Variable._publish')
+    @unittest.mock.patch("shc.variables.Variable._publish")
     @async_test
     async def test_basic_behaviour(self, publish_patch):
         var = variables.Variable(int)
@@ -91,22 +90,22 @@ class VariableFieldsTest(unittest.TestCase):
     async def test_field_subscribing(self):
         var = variables.Variable(ExampleTupleType)
         field_subscriber = ExampleWritable(int)
-        var.field('a').subscribe(field_subscriber)
+        var.field("a").subscribe(field_subscriber)
 
         with self.assertRaises(TypeError):
             var2 = variables.Variable(float)
-            await var2.field('c')  # type: ignore
+            await var2.field("c")  # type: ignore
 
         with self.assertRaises(KeyError):
-            await var.field('c')  # type: ignore
+            await var.field("c")  # type: ignore
 
         with self.assertRaises(base.UninitializedError):
-            await var.field('a').read()
+            await var.field("a").read()
 
         await var.write(ExampleTupleType(42, 3.1416), [self])
-        self.assertEqual(42, await var.field('a').read())
+        self.assertEqual(42, await var.field("a").read())
         await asyncio.sleep(0.01)
-        field_subscriber._write.assert_called_once_with(42, [self, var.field('a')])
+        field_subscriber._write.assert_called_once_with(42, [self, var.field("a")])
 
         field_subscriber._write.reset_mock()
         await var.write(ExampleTupleType(42, 2.719), [self])
@@ -119,11 +118,11 @@ class VariableFieldsTest(unittest.TestCase):
         other_field_subscriber = ExampleWritable(float)
         subscriber = ExampleWritable(ExampleTupleType)
         var.subscribe(subscriber)
-        var.field('a').subscribe(field_subscriber)
-        var.field('b').subscribe(other_field_subscriber)
+        var.field("a").subscribe(field_subscriber)
+        var.field("b").subscribe(other_field_subscriber)
 
         with self.assertRaises(base.UninitializedError):
-            await var.field('a').write(21, [self])
+            await var.field("a").write(21, [self])
 
         await var.write(ExampleTupleType(42, 3.1416), [self])
         await asyncio.sleep(0.01)
@@ -132,29 +131,29 @@ class VariableFieldsTest(unittest.TestCase):
         field_subscriber._write.reset_mock()
         other_field_subscriber._write.reset_mock()
 
-        await var.field('a').write(21, [self])
-        self.assertEqual(21, await var.field('a').read())
+        await var.field("a").write(21, [self])
+        self.assertEqual(21, await var.field("a").read())
         await asyncio.sleep(0.01)
-        subscriber._write.assert_called_once_with(ExampleTupleType(21, 3.1416), [self, var.field('a'), var])
-        field_subscriber._write.assert_called_once_with(21, [self, var.field('a'), var.field('a')])
+        subscriber._write.assert_called_once_with(ExampleTupleType(21, 3.1416), [self, var.field("a"), var])
+        field_subscriber._write.assert_called_once_with(21, [self, var.field("a"), var.field("a")])
         other_field_subscriber._write.assert_not_called()
 
     @async_test
     async def test_recursive_field_subscribing(self):
         var = variables.Variable(ExampleRecursiveTupleType)
         field_subscriber = ExampleWritable(int)
-        var.field('a').field('a').subscribe(field_subscriber)
+        var.field("a").field("a").subscribe(field_subscriber)
 
         with self.assertRaises(KeyError):
-            await var.field('a').field('c')  # type: ignore
+            await var.field("a").field("c")  # type: ignore
 
         with self.assertRaises(base.UninitializedError):
-            await var.field('a').field('a').read()
+            await var.field("a").field("a").read()
 
         await var.write(ExampleRecursiveTupleType(ExampleTupleType(42, 3.1416), 7), [self])
-        self.assertEqual(42, await var.field('a').field('a').read())
+        self.assertEqual(42, await var.field("a").field("a").read())
         await asyncio.sleep(0.01)
-        field_subscriber._write.assert_called_once_with(42, [self, var.field('a').field('a')])
+        field_subscriber._write.assert_called_once_with(42, [self, var.field("a").field("a")])
 
         field_subscriber._write.reset_mock()
         await var.write(ExampleRecursiveTupleType(ExampleTupleType(42, 3.1416), 6), [self])
@@ -201,10 +200,12 @@ class VariableFieldsTest(unittest.TestCase):
             self.assertEqual(21, await var.a.a.read())
             self.assertEqual(ExampleTupleType(21, 3.1416), await var.a.read())
             await asyncio.sleep(0.01)
-            subscriber._write.assert_called_once_with(ExampleRecursiveTupleType(ExampleTupleType(21, 3.1416), 7),
-                                                      [self, var.a.a, var.a, var])
+            subscriber._write.assert_called_once_with(
+                ExampleRecursiveTupleType(ExampleTupleType(21, 3.1416), 7), [self, var.a.a, var.a, var]
+            )
             intermediate_subscriber._write.assert_called_once_with(
-                ExampleTupleType(21, 3.1416), [self, var.a.a, var.a, var.a])
+                ExampleTupleType(21, 3.1416), [self, var.a.a, var.a, var.a]
+            )
             field_subscriber._write.assert_called_once_with(21, [self, var.a.a, var.a, var.a.a])
             other_field_subscriber._write.assert_not_called()
             another_field_subscriber._write.assert_not_called()
@@ -218,13 +219,13 @@ class VariableFieldsTest(unittest.TestCase):
         other_field_subscriber = ExampleWritable(float)
         another_field_subscriber = ExampleWritable(int)
         var.subscribe(subscriber)
-        var.field('a').subscribe(intermediate_subscriber)
-        var.field('a').field('a').subscribe(field_subscriber)
-        var.field('a').field('b').subscribe(other_field_subscriber)
-        var.field('b').subscribe(another_field_subscriber)
+        var.field("a").subscribe(intermediate_subscriber)
+        var.field("a").field("a").subscribe(field_subscriber)
+        var.field("a").field("b").subscribe(other_field_subscriber)
+        var.field("b").subscribe(another_field_subscriber)
 
         with self.assertRaises(base.UninitializedError):
-            await var.field('a').field('a').write(21, [self])
+            await var.field("a").field("a").write(21, [self])
 
         await var.write(ExampleRecursiveTupleType(ExampleTupleType(42, 3.1416), 7), [self])
         await asyncio.sleep(0.01)
@@ -235,33 +236,35 @@ class VariableFieldsTest(unittest.TestCase):
         other_field_subscriber._write.reset_mock()
         another_field_subscriber._write.reset_mock()
 
-        await var.field('a').field('a').write(21, [self])
-        self.assertEqual(21, await var.field('a').field('a').read())
-        self.assertEqual(ExampleTupleType(21, 3.1416), await var.field('a').read())
+        await var.field("a").field("a").write(21, [self])
+        self.assertEqual(21, await var.field("a").field("a").read())
+        self.assertEqual(ExampleTupleType(21, 3.1416), await var.field("a").read())
         await asyncio.sleep(0.01)
-        subscriber._write.assert_called_once_with(ExampleRecursiveTupleType(ExampleTupleType(21, 3.1416), 7),
-                                                  [self, var.field('a').field('a'), var.field('a'), var])
+        subscriber._write.assert_called_once_with(
+            ExampleRecursiveTupleType(ExampleTupleType(21, 3.1416), 7),
+            [self, var.field("a").field("a"), var.field("a"), var],
+        )
         intermediate_subscriber._write.assert_called_once_with(
-            ExampleTupleType(21, 3.1416),
-            [self, var.field('a').field('a'), var.field('a'), var.field('a')])
+            ExampleTupleType(21, 3.1416), [self, var.field("a").field("a"), var.field("a"), var.field("a")]
+        )
         field_subscriber._write.assert_called_once_with(
-            21,
-            [self, var.field('a').field('a'), var.field('a'), var.field('a').field('a')])
+            21, [self, var.field("a").field("a"), var.field("a"), var.field("a").field("a")]
+        )
         other_field_subscriber._write.assert_not_called()
         another_field_subscriber._write.assert_not_called()
 
     @async_test
     async def test_expression_wrapper(self):
         var = variables.Variable(ExampleTupleType, initial_value=ExampleTupleType(42, 3.1416))
-        wrapper = var.field('a').EX
+        wrapper = var.field("a").EX
         subscriber = ExampleWritable(int)
         wrapper.subscribe(subscriber)
 
         self.assertIsInstance(wrapper, expressions.ExpressionBuilder)
         self.assertEqual(42, await wrapper.read())
-        await var.field('a').write(21, [self])
+        await var.field("a").write(21, [self])
         await asyncio.sleep(0.01)
-        subscriber._write.assert_called_with(21, [self, var.field('a'), var.field('a')])
+        subscriber._write.assert_called_with(21, [self, var.field("a"), var.field("a")])
 
 
 class ConnectedVariablesTest(unittest.TestCase):
@@ -278,14 +281,14 @@ class ConnectedVariablesTest(unittest.TestCase):
     async def test_concurrent_field_update_publishing(self) -> None:
         var1 = variables.Variable(ExampleTupleType)
         var2 = variables.Variable(ExampleTupleType).connect(var1)
-        var3 = variables.Variable(int).connect(var2.field('a'))
+        var3 = variables.Variable(int).connect(var2.field("a"))
 
-        writable1 = ExampleWritable(int).connect(var1.field('a'))  # TODO add different delays
+        writable1 = ExampleWritable(int).connect(var1.field("a"))  # TODO add different delays
         writable3 = ExampleWritable(int).connect(var3)
 
         await asyncio.gather(var1.write(ExampleTupleType(42, 3.1416), []), var3.write(56, []))
         await asyncio.sleep(0.1)
-        self.assertEqual(await var1.field('a').read(), await var3.read())
+        self.assertEqual(await var1.field("a").read(), await var3.read())
 
         self.assertLessEqual(writable1._write.call_count, 3)
         self.assertLessEqual(writable3._write.call_count, 3)
@@ -310,30 +313,32 @@ class DelayedVariableTest(unittest.TestCase):
 
     @async_test
     async def test_field_update(self):
-        var = variables.DelayedVariable(ExampleTupleType,
-                                        name="A test variable",
-                                        initial_value=ExampleTupleType(0, 0.0),
-                                        publish_delay=datetime.timedelta(seconds=0.02))
+        var = variables.DelayedVariable(
+            ExampleTupleType,
+            name="A test variable",
+            initial_value=ExampleTupleType(0, 0.0),
+            publish_delay=datetime.timedelta(seconds=0.02),
+        )
         field_subscriber = ExampleWritable(int)
         subscriber = ExampleWritable(ExampleTupleType)
         var.subscribe(subscriber)
-        var.field('a').subscribe(field_subscriber)
+        var.field("a").subscribe(field_subscriber)
 
-        await var.field('a').write(21, [self])
+        await var.field("a").write(21, [self])
         await asyncio.sleep(0)
-        await var.field('b').write(3.1416, [self])
+        await var.field("b").write(3.1416, [self])
         self.assertEqual(ExampleTupleType(21, 3.1416), await var.read())
         await asyncio.sleep(0.025)
-        subscriber._write.assert_called_once_with(ExampleTupleType(21, 3.1416), [self, var.field('b'), var])
-        field_subscriber._write.assert_called_once_with(21, [self, var.field('b'), var.field('a')])
+        subscriber._write.assert_called_once_with(ExampleTupleType(21, 3.1416), [self, var.field("b"), var])
+        field_subscriber._write.assert_called_once_with(21, [self, var.field("b"), var.field("a")])
 
 
 class MyPyPluginTest(unittest.TestCase):
     def test_mypy_plugin_variable(self) -> None:
-        asset_dir = Path(__file__).parent / 'assets' / 'mypy_plugin_test'
-        result = mypy.api.run(['--config-file',
-                               str(asset_dir / 'mypy.ini'),
-                               str(asset_dir / 'variable_typing_example.py')])
+        asset_dir = Path(__file__).parent / "assets" / "mypy_plugin_test"
+        result = mypy.api.run(
+            ["--config-file", str(asset_dir / "mypy.ini"), str(asset_dir / "variable_typing_example.py")]
+        )
         self.assertIn("variable_typing_example.py:22: error", result[0])
         self.assertNotIn("variable_typing_example.py:23: error", result[0])
         self.assertIn("variable_typing_example.py:25: error", result[0])
@@ -344,10 +349,10 @@ class MyPyPluginTest(unittest.TestCase):
         self.assertEqual(1, result[2])
 
     def test_mypy_plugin_exchange(self) -> None:
-        asset_dir = Path(__file__).parent / 'assets' / 'mypy_plugin_test'
-        result = mypy.api.run(['--config-file',
-                               str(asset_dir / 'mypy.ini'),
-                               str(asset_dir / 'exchange_typing_example.py')])
+        asset_dir = Path(__file__).parent / "assets" / "mypy_plugin_test"
+        result = mypy.api.run(
+            ["--config-file", str(asset_dir / "mypy.ini"), str(asset_dir / "exchange_typing_example.py")]
+        )
         self.assertIn("exchange_typing_example.py:24: error", result[0])
         self.assertIn("exchange_typing_example.py:25: error", result[0])
         self.assertNotIn("exchange_typing_example.py:26: error", result[0])


### PR DESCRIPTION
### Reformating code:

no other manual changes except for this line in pyproject.toml (see https://github.com/jo47011/smarthomeconnect/pull/5/commits/cef39f89453018398cf3beeb8a5591a49c85513d)  and two fixes mentioned below:
```bash
[tool.ruff.format]
# Like Black, use double quotes for strings.
quote-style = "double"
```

- Invoked:
```bash
ruff format .
```

- Moved the `#noqa E501` to another line in `test_pulse.py` to fix lint error. (see https://github.com/jo47011/smarthomeconnect/pull/5/commits/f88893bf641ca7617a31aa7b6ff75120916f81f8#)

- Added a type ignore in shc/web/widgets.py:646 to please mypy. (see https://github.com/jo47011/smarthomeconnect/pull/5/commits/a106ac1bbbff3f0499a7a1b446a3bdd0dda40732)

Thus all changes in this commit are plain formatting fixes.  No logic should have changed.
